### PR TITLE
Fix analysis-runner failure handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,5 +170,6 @@ artifacts/
 catboost_info/
 .claude/*
 !.claude/settings.json
+agents/analyst/analysis-errors.md
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Important untracked paths:
 - `data/`
 - `artifacts/`
 - `.claude/settings.local.json`
+- `agents/analyst/analysis-errors.md`
 
 ## Notes
 

--- a/agents/analyst/role.md
+++ b/agents/analyst/role.md
@@ -18,6 +18,7 @@ Answer hypotheses posed by the supervisor with rigorous evidence. Surface patter
 - **Branch:** `autokaggle/<tag>/analyst`
 - **Worktree:** `<root>/AutoKaggle-<tag>-analyst/`
 - **Tracked files you own:** `agents/analyst/analysis.py`, `agents/analyst/analyst-findings.md`
+- **Local debug log:** `agents/analyst/analysis-errors.md` (ignored; do not commit)
 
 Refer to `program.md` for the definition of `<root>` and for how to initialise your branch and worktree.
 
@@ -106,14 +107,15 @@ ON EACH /loop WAKE:
    uv run python -m harness.analysis_runner \
      --hypothesis-file $REPO/agents/analyst/analyst-hypotheses.md \
      --findings-file agents/analyst/analyst-findings.md
-7. Review the appended entry in agents/analyst/analyst-findings.md
-8. Fill in Verdict, Implications, and any Suggested next hypotheses
-9. Commit agents/analyst/analysis.py and agents/analyst/analyst-findings.md
+7. If the harness succeeds, review the appended entry in agents/analyst/analyst-findings.md.
+8. If the harness fails, inspect agents/analyst/analysis-errors.md, fix agents/analyst/analysis.py, and rerun before editing findings.
+9. Fill in Verdict, Implications, and any Suggested next hypotheses only after a successful append.
+10. Commit agents/analyst/analysis.py and agents/analyst/analyst-findings.md. Do not commit analysis-errors.md.
 ```
 
 ## Writing agents/analyst/analysis.py
 
-`agents/analyst/analysis.py` is your working script for each investigation. The analysis runner executes it by explicit path and captures its stdout to append into `agents/analyst/analyst-findings.md`. Structure your script to print clearly labelled findings. Output tables and metrics, not plots:
+`agents/analyst/analysis.py` is your working script for each investigation. The analysis runner executes it by explicit path. On success it captures stdout and appends it into `agents/analyst/analyst-findings.md`. On failure it writes stdout and stderr to `agents/analyst/analysis-errors.md` instead of polluting the durable findings history. Structure your script to print clearly labelled findings. Output tables and metrics, not plots:
 
 ```python
 import pickle
@@ -138,7 +140,7 @@ Use `sklearn`, `numpy`, `pandas`, and `shap` freely. Do not call `.fit()`. Do no
 
 ## Output Format
 
-The analysis runner appends one entry per run to `agents/analyst/analyst-findings.md`:
+Successful analysis runs append one entry to `agents/analyst/analyst-findings.md`:
 
 ```markdown
 ## <short title>
@@ -157,7 +159,9 @@ The analysis runner appends one entry per run to `agents/analyst/analyst-finding
 - <specific, falsifiable question>
 ```
 
-After the runner writes the entry, fill in **Verdict**, **Implications**, and any **Suggested next hypotheses** by editing the file directly before committing.
+Failed analysis runs do not append a normal findings entry. They write a separate debugging record to `agents/analyst/analysis-errors.md` with the hypothesis, exit code, stdout, and stderr.
+
+After a successful append, fill in **Verdict**, **Implications**, and any **Suggested next hypotheses** by editing the findings file directly before committing.
 
 Append only. Do not overwrite previous entries. The supervisor reads the full history.
 

--- a/harness/analysis_runner.py
+++ b/harness/analysis_runner.py
@@ -7,11 +7,13 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ANALYSIS_PATH = Path("agents/analyst/analysis.py")
+DEFAULT_ERRORS_FILENAME = "analysis-errors.md"
 
 
 def main() -> None:
     args = _parse_args()
     analysis_path = _normalize_repo_path(args.analysis_path)
+    errors_file = args.errors_file or args.findings_file.with_name(DEFAULT_ERRORS_FILENAME)
 
     hypothesis_text = args.hypothesis_file.read_text()
     title = _extract_title(hypothesis_text)
@@ -24,27 +26,23 @@ def main() -> None:
         text=True,
     )
 
-    args.findings_file.parent.mkdir(parents=True, exist_ok=True)
-    with args.findings_file.open("a") as f:
-        if f.tell() > 0:
-            f.write("\n\n")
-        f.write(f"## {title}\n")
-        f.write(f"*{_utc_timestamp()}*\n\n")
-        f.write("**Hypothesis:**\n")
-        f.write(f"{hypothesis_text.rstrip()}\n\n")
-        f.write("**Verdict:** *(fill in: Supported / Rejected / Inconclusive)*\n\n")
-        f.write("**Evidence:**\n")
-        f.write(f"{_format_evidence(completed.stdout, completed.stderr, completed.returncode)}\n\n")
-        f.write("**Implications:**\n")
-        f.write("*(fill in)*\n\n")
-        f.write("**Suggested next hypotheses:** *(optional)*\n")
-        f.write("*(fill in or delete)*\n")
-
     if completed.returncode != 0:
-        print(
-            f"warning: {analysis_path} exited with code {completed.returncode}; stderr was appended to the findings entry",
-            file=sys.stderr,
+        _append_failure_entry(
+            errors_file=errors_file,
+            title=title,
+            hypothesis_text=hypothesis_text,
+            analysis_path=analysis_path,
+            completed=completed,
         )
+        _report_failure(analysis_path=analysis_path, errors_file=errors_file, completed=completed)
+        raise SystemExit(completed.returncode)
+
+    _append_findings_entry(
+        findings_file=args.findings_file,
+        title=title,
+        hypothesis_text=hypothesis_text,
+        stdout=completed.stdout,
+    )
 
 
 def _parse_args() -> argparse.Namespace:
@@ -52,6 +50,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--analysis-path", type=Path, default=DEFAULT_ANALYSIS_PATH)
     parser.add_argument("--hypothesis-file", type=Path, required=True)
     parser.add_argument("--findings-file", type=Path, required=True)
+    parser.add_argument("--errors-file", type=Path)
     return parser.parse_args()
 
 
@@ -70,10 +69,18 @@ def _analysis_env() -> dict[str, str]:
 
 
 def _extract_title(hypothesis_text: str) -> str:
-    for line in hypothesis_text.splitlines():
+    lines = hypothesis_text.splitlines()
+    for index, line in enumerate(lines):
         stripped = line.strip()
-        if stripped.startswith("**Question:**"):
-            return stripped.removeprefix("**Question:**").strip() or "Analysis"
+        for prefix in ("**Hypothesis:**", "**Question:**"):
+            if not stripped.startswith(prefix):
+                continue
+            title = stripped.removeprefix(prefix).strip()
+            if title:
+                return title
+            fallback_title = _next_nonempty_line(lines[index + 1 :])
+            if fallback_title:
+                return fallback_title
     return "Analysis"
 
 
@@ -81,15 +88,82 @@ def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
 
 
-def _format_evidence(stdout: str, stderr: str, returncode: int) -> str:
-    sections: list[str] = []
-    if stdout.strip():
-        sections.append(stdout.rstrip())
-    if returncode != 0 and stderr.strip():
-        sections.append(f"[stderr]\n{stderr.rstrip()}")
-    if not sections:
+def _append_findings_entry(findings_file: Path, title: str, hypothesis_text: str, stdout: str) -> None:
+    findings_file.parent.mkdir(parents=True, exist_ok=True)
+    with findings_file.open("a") as f:
+        if f.tell() > 0:
+            f.write("\n\n")
+        f.write(f"## {title}\n")
+        f.write(f"*{_utc_timestamp()}*\n\n")
+        f.write("**Hypothesis:**\n")
+        f.write(f"{hypothesis_text.rstrip()}\n\n")
+        f.write("**Verdict:** *(fill in: Supported / Rejected / Inconclusive)*\n\n")
+        f.write("**Evidence:**\n")
+        f.write(f"{_format_stream(stdout)}\n\n")
+        f.write("**Implications:**\n")
+        f.write("*(fill in)*\n\n")
+        f.write("**Suggested next hypotheses:** *(optional)*\n")
+        f.write("*(fill in or delete)*\n")
+
+
+def _append_failure_entry(
+    errors_file: Path,
+    title: str,
+    hypothesis_text: str,
+    analysis_path: Path,
+    completed: subprocess.CompletedProcess[str],
+) -> None:
+    errors_file.parent.mkdir(parents=True, exist_ok=True)
+    with errors_file.open("a") as f:
+        if f.tell() > 0:
+            f.write("\n\n")
+        f.write(f"## {title}\n")
+        f.write(f"*{_utc_timestamp()}*\n\n")
+        f.write("**Hypothesis:**\n")
+        f.write(f"{hypothesis_text.rstrip()}\n\n")
+        f.write(f"**Analysis path:** `{_display_path(analysis_path)}`\n\n")
+        f.write(f"**Exit code:** `{completed.returncode}`\n\n")
+        f.write("**Stdout:**\n")
+        f.write(f"{_format_stream(completed.stdout)}\n\n")
+        f.write("**Stderr:**\n")
+        f.write(f"{_format_stream(completed.stderr)}\n")
+
+
+def _report_failure(
+    analysis_path: Path, errors_file: Path, completed: subprocess.CompletedProcess[str]
+) -> None:
+    print(
+        f"error: {_display_path(analysis_path)} exited with code {completed.returncode}; details written to {_display_path(errors_file)}",
+        file=sys.stderr,
+    )
+    if completed.stdout.strip():
+        print("\n[analysis stdout]", file=sys.stderr)
+        print(completed.stdout.rstrip(), file=sys.stderr)
+    if completed.stderr.strip():
+        print("\n[analysis stderr]", file=sys.stderr)
+        print(completed.stderr.rstrip(), file=sys.stderr)
+
+
+def _next_nonempty_line(lines: list[str]) -> str | None:
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _format_stream(stream: str) -> str:
+    if not stream.strip():
         return "*(no output)*"
-    return "\n\n".join(sections)
+    return stream.rstrip()
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis_runner.py
+++ b/tests/test_analysis_runner.py
@@ -1,0 +1,102 @@
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+from harness import analysis_runner
+
+
+class AnalysisRunnerTests(unittest.TestCase):
+    def test_success_appends_findings_without_stderr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            hypothesis_file = root / "hypothesis.md"
+            findings_file = root / "findings.md"
+            hypothesis_file.write_text("# Active Hypothesis\n\n**Hypothesis:** Does feature hashing help?\n")
+
+            completed = subprocess.CompletedProcess(
+                args=["python", "analysis.py"],
+                returncode=0,
+                stdout="Finding: yes\n",
+                stderr="debug noise\n",
+            )
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "analysis_runner",
+                    "--hypothesis-file",
+                    str(hypothesis_file),
+                    "--findings-file",
+                    str(findings_file),
+                ],
+            ), mock.patch("harness.analysis_runner.subprocess.run", return_value=completed):
+                analysis_runner.main()
+
+            findings = findings_file.read_text()
+            self.assertIn("## Does feature hashing help?", findings)
+            self.assertIn("**Evidence:**\nFinding: yes", findings)
+            self.assertNotIn("debug noise", findings)
+            self.assertFalse((root / "analysis-errors.md").exists())
+
+    def test_failure_skips_findings_and_writes_error_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            hypothesis_file = root / "hypothesis.md"
+            findings_file = root / "findings.md"
+            findings_file.write_text("## Existing finding\n")
+            hypothesis_file.write_text("# Active Hypothesis\n\n**Hypothesis:** Does feature hashing help?\n")
+
+            completed = subprocess.CompletedProcess(
+                args=["python", "analysis.py"],
+                returncode=2,
+                stdout="partial output\n",
+                stderr="Traceback: boom\n",
+            )
+
+            stderr = io.StringIO()
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "analysis_runner",
+                    "--hypothesis-file",
+                    str(hypothesis_file),
+                    "--findings-file",
+                    str(findings_file),
+                ],
+            ), mock.patch("harness.analysis_runner.subprocess.run", return_value=completed), redirect_stderr(
+                stderr
+            ):
+                with self.assertRaises(SystemExit) as exc:
+                    analysis_runner.main()
+
+            self.assertEqual(exc.exception.code, 2)
+            self.assertEqual(findings_file.read_text(), "## Existing finding\n")
+
+            errors = (root / "analysis-errors.md").read_text()
+            self.assertIn("## Does feature hashing help?", errors)
+            self.assertIn("**Exit code:** `2`", errors)
+            self.assertIn("**Stdout:**\npartial output", errors)
+            self.assertIn("**Stderr:**\nTraceback: boom", errors)
+
+            stderr_text = stderr.getvalue()
+            self.assertIn("details written to", stderr_text)
+            self.assertIn("[analysis stdout]", stderr_text)
+            self.assertIn("[analysis stderr]", stderr_text)
+
+    def test_extract_title_prefers_hypothesis_and_supports_multiline(self) -> None:
+        self.assertEqual(
+            analysis_runner._extract_title("# Active Hypothesis\n\n**Hypothesis:**\nDoes feature hashing help?\n"),
+            "Does feature hashing help?",
+        )
+        self.assertEqual(analysis_runner._extract_title("**Question:** Legacy title"), "Legacy title")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stop appending normal findings entries when analysis runs fail
- write failure details to a separate local analysis error log and report the failure clearly
- align title extraction with the current hypothesis template and add regression tests

## Testing
- uv run python -m unittest discover -s tests -v

Fixes #7