### PR TITLE
Simplify the run workflow around a single run branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The current documented operating model on `main` uses one long-lived role plus t
 - Run `uv sync`.
 - Configure Kaggle authentication on your machine before starting a run.
 - Make sure your Kaggle account has access to the target competition and has accepted any required rules.
-- Start Claude Code from within the repository or worktree directories created for the run.
+- Start Claude Code from within the repository root.
 
 ## Starting A Run
 
@@ -58,7 +58,7 @@ You are the supervisor, start a new run.
 ```
 
 3. The supervisor will:
-   - propose a run tag
+   - create or update the long-lived `run` branch
    - prepare the run state
    - ensure competition data exists
    - initialize the tracked communication files under `agents/`
@@ -93,7 +93,7 @@ Useful places to inspect:
 - [agents/analyst/analyst-findings.md](agents/analyst/analyst-findings.md) when present
 - [agents/analyst/analyst-knowledge.md](agents/analyst/analyst-knowledge.md) when present
 - [agents/supervisor/leaderboard-history.md](agents/supervisor/leaderboard-history.md) when present
-- `artifacts/<tag>/` for untracked run outputs
+- `artifacts/` for untracked run outputs
 
 ## Repository Layout
 
@@ -141,8 +141,7 @@ Example invocation:
 ```bash
 uv run python -m harness.promotion_runner \
   --hash <hash> \
-  --tag <tag> \
-  --artifact-dir artifacts/<tag>/experiments/<hash> \
+  --artifact-dir artifacts/experiments/<hash> \
   --cv-score <cv_score>
 ```
 
@@ -150,4 +149,5 @@ uv run python -m harness.promotion_runner \
 
 - The committed [`.claude/settings.json`](.claude/settings.json) is project-wide and path-free.
 - Machine-specific permissions and directories belong only in untracked local Claude settings.
+- The supervisor is the only agent that commits tracked changes.
 - Do not push local run state, local Claude state, downloaded Kaggle data, or generated artifacts.

--- a/agents/analyst/role.md
+++ b/agents/analyst/role.md
@@ -22,13 +22,13 @@ You are invoked only when the supervisor has a concrete yes/no hypothesis to tes
 1. read the active hypothesis and relevant context
 2. run one investigation
 3. append one durable findings entry
-4. commit your owned files
+4. leave your tracked changes for the supervisor to review
 5. stop or idle until the next explicit invocation
 
 ## Git Setup
 
-- **Branch:** `autokaggle/<tag>/supervisor`
-- **Directory:** `<root>/AutoKaggle/` (same repo as the supervisor; no separate analyst worktree)
+- **Branch:** `run`
+- **Directory:** `<root>/AutoKaggle/` (same repo as the supervisor)
 - **Tracked files you own during an investigation:** `agents/analyst/analysis.py`, `agents/analyst/analyst-findings.md`, `agents/analyst/analyst-knowledge.md`
 - **Local debug log:** `agents/analyst/analysis-errors.md` (ignored; do not commit)
 
@@ -36,15 +36,15 @@ Refer to `program.md` for the definition of `<root>` and for the shared repo lay
 
 ## Path Variables
 
-Define these once on invocation (substitute real values for `<root>` and `<tag>`):
+Define these once on invocation:
 
 ```bash
 REPO=<root>/AutoKaggle
 DATA=$REPO/data
-ARTIFACTS=$REPO/artifacts/<tag>
+ARTIFACTS=$REPO/artifacts
 ```
 
-Resolve these dynamically at runtime from your current branch and worktree layout. Do not commit machine-specific paths.
+Resolve these dynamically at runtime from your current checkout. Do not commit machine-specific paths.
 
 ## Cross-Agent File Paths
 
@@ -71,7 +71,7 @@ git show <hash>:agents/scientist/experiment.py
 
 On each invocation:
 
-1. Confirm you are in `<root>/AutoKaggle/` on branch `autokaggle/<tag>/supervisor`
+1. Confirm you are in `<root>/AutoKaggle/` on branch `run`
 2. Reuse the current repo's local Claude settings if they already exist. If you need to create or update `.claude/settings.local.json` to read shared data or shared artifacts, ask the human once for permission first.
 3. Ensure the current repo can read the shared data and shared artifacts it needs
 4. Read the following in order:
@@ -81,7 +81,7 @@ On each invocation:
    - `$REPO/agents/analyst/analyst-hypothesis.md`
 5. Read `$REPO/agents/scientist/scientist-results.md`, `$REPO/agents/scientist/experiment.py`, `$DATA/train.csv`, `$DATA/test.csv`, and any referenced artifacts only when needed for the active hypothesis
 6. Initialise `agents/analyst/analyst-findings.md` and `agents/analyst/analyst-knowledge.md` with just headers if they do not exist yet
-7. Run exactly one investigation, append the result, update knowledge if warranted, commit your owned files, and stop
+7. Run exactly one investigation, append the result, update knowledge if warranted, leave your tracked changes for the supervisor to commit, and stop
 
 ## Boundaries
 
@@ -91,7 +91,6 @@ On each invocation:
 - Run EDA on training and test data, but report evidence only as text, tables, counts, and metrics
 - Write `agents/analyst/analysis.py` — your working script for each investigation
 - Run `harness/analysis_runner.py` to execute your analysis and record findings
-- Commit `agents/analyst/analysis.py`, `agents/analyst/analyst-findings.md`, and `agents/analyst/analyst-knowledge.md`
 - Create or update `.claude/settings.local.json` in the current repo
 - Ask the human for any new package, permission, or capability you need
 
@@ -102,6 +101,7 @@ On each invocation:
 - Write to `agents/analyst/analyst-hypothesis.md`. Suggested follow-on questions go into your findings for the supervisor to evaluate.
 - Install packages or modify dependencies
 - Create plots, charts, or other visual outputs unless the human explicitly asks
+- Commit tracked files
 
 ## Workflow
 
@@ -120,7 +120,7 @@ ON EACH INVOCATION:
 7. If the harness fails, inspect agents/analyst/analysis-errors.md, fix agents/analyst/analysis.py, and rerun before editing findings.
 8. Fill in `verdict`, `conf`, optional `reference`, and exactly 3 `follow_up` hypotheses only after a successful append.
 9. Update `agents/analyst/analyst-knowledge.md` only if the result produced a durable reusable fact.
-10. Commit agents/analyst/analysis.py, agents/analyst/analyst-findings.md, and agents/analyst/analyst-knowledge.md. Do not commit analysis-errors.md.
+10. Stop and leave `agents/analyst/analysis.py`, `agents/analyst/analyst-findings.md`, and `agents/analyst/analyst-knowledge.md` for the supervisor to review and commit. Do not commit `analysis-errors.md`.
 11. Stop or go idle until the next explicit invocation.
 ```
 
@@ -133,7 +133,7 @@ import pickle
 import numpy as np
 import pandas as pd
 
-ARTIFACTS_ROOT = "<root>/AutoKaggle/artifacts/<tag>/experiments"
+ARTIFACTS_ROOT = "<root>/AutoKaggle/artifacts/experiments"
 DATA = "<root>/AutoKaggle/data"
 
 def main():
@@ -173,7 +173,7 @@ Failed analysis runs do not append a normal findings entry. They write a separat
 
 `reference:` is optional. `follow_up:` is mandatory and should contain exactly 3 concise yes/no hypotheses.
 
-After a successful append, fill in `verdict`, `conf`, optional `reference`, and `follow_up` directly before committing.
+After a successful append, fill in `verdict`, `conf`, optional `reference`, and `follow_up` directly before stopping.
 
 Append only. Do not overwrite previous entries. The supervisor reads the full history.
 

--- a/agents/program.md
+++ b/agents/program.md
@@ -45,6 +45,9 @@ Episodic roles:
 - The scientist reads one active task at a time, executes one experiment cycle, and records only terminal evaluated runs in `agents/scientist/scientist-results.md`.
 - Invalid scientist launches are repaired inside the same invocation and do not count as completed experiment results.
 - The scientist follows the supervisor's current lane. CV is the default local scorekeeper, not the sole objective.
+- The supervisor is the only agent that commits tracked changes.
+- The supervisor commits only at quiescent points, after all active strategist, analyst, and scientist work has finished.
+- `agents/scientist/scientist-task.md` and `agents/analyst/analyst-hypothesis.md` are tracked live-control files, but they should normally be cleared back to `status: none` before the supervisor commits a checkpoint.
 - No agent installs packages, modifies dependencies, or changes the environment on its own.
 - If an agent needs a new package, new permission, or any capability it does not already have, it asks the human.
 
@@ -52,9 +55,9 @@ Episodic roles:
 
 ## Shared Runtime Assumptions
 
-- The human starts the supervisor first. The supervisor provisions the run tag, branches, worktrees, and initial tracked communication files before the rest of the team begins normal work.
+- The human starts the supervisor first. The supervisor creates or updates the long-lived `run` branch, ensures the initial tracked communication files exist, and then manages all later commits.
 - The strategist, analyst, and scientist are on-demand, not permanently polling. They are invoked in the current repo only when needed.
-- Per-agent Claude settings belong in untracked `.claude/settings.local.json` files inside the current repo or worktree.
+- Per-agent Claude settings belong in untracked `.claude/settings.local.json` files inside the current repo.
 - The committed [`.claude/settings.json`](../.claude/settings.json) is shared and must stay path-free.
 - Coordination in this repository is polling-based. Do not rely on file hooks or sentinel writes as part of the documented control flow.
 
@@ -62,7 +65,7 @@ Episodic roles:
 
 ## Directory Layout
 
-`<root>` is the parent directory where the repository lives (for example `~/dev`). All worktrees share the same `.git` object store.
+`<root>` is the parent directory where the repository lives (for example `~/dev`).
 
 ```text
 <root>/
@@ -91,7 +94,7 @@ Episodic roles:
         scientist-knowledge.md       # concise durable scientist memory
     harness/                         # shared harness code
     data/                            # competition data (untracked, shared)
-    artifacts/<tag>/                 # run artifacts (untracked, shared)
+    artifacts/                       # untracked runtime artifacts
       experiments/<hash>/
         run.log
         exit-code.txt
@@ -104,7 +107,7 @@ Episodic roles:
 
 ## Communication Files
 
-All inter-agent coordination flows through tracked files committed in the appropriate repo or worktree location, read by others through paths resolved dynamically at runtime from the repo and worktree layout.
+All inter-agent coordination flows through tracked files in the repository, read by others through paths resolved dynamically at runtime from the current checkout.
 
 | File | Owned by | Read by | Lives in |
 |------|----------|---------|----------|
@@ -118,7 +121,7 @@ All inter-agent coordination flows through tracked files committed in the approp
 | `agents/scientist/scientist-results.md` | Scientist | Supervisor, Analyst, Strategist | `AutoKaggle/` |
 | `agents/scientist/scientist-knowledge.md` | Scientist | Scientist, Supervisor | `AutoKaggle/` |
 
-Binary artifacts (`oof-preds.npy`, `model.pkl`, `test-preds.npy`) are never committed. They live in `AutoKaggle/artifacts/<tag>/experiments/<hash>/` and are accessed by all agents via absolute path. Per-run logs and exit-code files may live beside them as untracked local runtime state.
+Binary artifacts (`oof-preds.npy`, `model.pkl`, `test-preds.npy`) are never committed. They live in `AutoKaggle/artifacts/experiments/<hash>/` and are accessed by all agents via absolute path. Per-run logs and exit-code files may live beside them as untracked local runtime state.
 
 ---
 
@@ -150,7 +153,7 @@ When `stop` is given, every agent should:
 2. Cancel any active `/loop` scheduled task it started.
 3. Do not create any new scheduled tasks.
 4. Finish only the current atomic checkpoint.
-5. Commit its owned status files if needed.
+5. Only the supervisor may commit tracked checkpoint files if needed.
 6. Report a final status note, then go idle or exit.
 
 There is no automatic stopping condition besides an explicit human stop.

--- a/agents/scientist/role.md
+++ b/agents/scientist/role.md
@@ -23,11 +23,12 @@ One invocation should do exactly one full scientist cycle:
 2. edit `agents/scientist/experiment.py`
 3. run the scientist harness
 4. if the run is invalid, fix the experiment and retry inside the same invocation
-5. if the run reaches a terminal outcome, record it, update scientist knowledge if warranted, commit your owned files, and stop
+5. if the run reaches a terminal outcome, record it, update scientist knowledge if warranted, leave your tracked changes for the supervisor to review, and stop
 
 ## Git Setup
 
-- **Directory:** current scientist checkout
+- **Branch:** `run`
+- **Directory:** `<root>/AutoKaggle/` (same repo as the supervisor)
 - **Tracked files you own during an investigation:** `agents/scientist/experiment.py`, `agents/scientist/scientist-results.md`, `agents/scientist/scientist-knowledge.md`
 - **Local debug log:** `agents/scientist/scientist-errors.md` (ignored; do not commit)
 
@@ -38,9 +39,9 @@ Refer to `program.md` for the shared repo layout.
 Define these once on invocation:
 
 ```bash
-REPO=<current repo root>
+REPO=<root>/AutoKaggle
 DATA=$REPO/data
-ARTIFACTS=$REPO/artifacts/<tag>
+ARTIFACTS=$REPO/artifacts
 ```
 
 Resolve these dynamically at runtime from your current checkout. Do not commit machine-specific paths.
@@ -64,7 +65,7 @@ $REPO/harness/scientist_runner.py
 
 On each invocation:
 
-1. Confirm you are in the intended scientist checkout.
+1. Confirm you are in `<root>/AutoKaggle/` on branch `run`.
 2. Reuse the current repo's local Claude settings if they already exist. If you need to create or update `.claude/settings.local.json` to read shared data or artifacts, ask the human once for permission first.
 3. Read the following in order:
    - `$REPO/agents/program.md`
@@ -74,14 +75,13 @@ On each invocation:
 4. Read `$REPO/harness/dataset.py`, `$REPO/harness/experiment_runner.py`, and `$REPO/harness/scientist_runner.py` when needed for execution details.
 5. Read analyst findings, analyst knowledge, or leaderboard history only when the active task references them or when they are needed to implement the requested experiment.
 6. Initialise `agents/scientist/scientist-results.md` and `agents/scientist/scientist-knowledge.md` with just headers if they do not exist yet.
-7. Run exactly one scientist cycle, commit your owned files, and stop.
+7. Run exactly one scientist cycle, leave your tracked changes for the supervisor to commit, and stop.
 
 ## Boundaries
 
 **What you CAN do:**
 - Edit `agents/scientist/experiment.py` freely: feature engineering, preprocessing, model architecture, hyperparameters, ensembles, anything
 - Run the scientist harness
-- Commit `agents/scientist/experiment.py`, `agents/scientist/scientist-results.md`, and `agents/scientist/scientist-knowledge.md`
 - Write binary artifacts to `$ARTIFACTS/` when the runner is given an artifact root
 - Create or update `.claude/settings.local.json` in the current repo
 - Ask the human for any new package, permission, or capability you need
@@ -92,6 +92,7 @@ On each invocation:
 - Submit to Kaggle
 - Write to any other agent's files
 - Write to `agents/scientist/scientist-task.md`
+- Commit tracked files
 
 ## Active Task
 
@@ -128,7 +129,7 @@ ON EACH INVOCATION:
 5. If the runner returns `invalid`, inspect `agents/scientist/scientist-errors.md`, fix `agents/scientist/experiment.py`, and rerun inside the same invocation.
 6. If the runner returns a terminal outcome (`kept`, `discarded`, `timeout`, or `error`), review the appended row in `agents/scientist/scientist-results.md`.
 7. Update `agents/scientist/scientist-knowledge.md` only if the run produced a durable reusable fact.
-8. Commit your owned files and stop.
+8. Stop and leave `agents/scientist/experiment.py`, `agents/scientist/scientist-results.md`, and `agents/scientist/scientist-knowledge.md` for the supervisor to review and commit.
 ```
 
 Do not treat an invalid run as a completed experiment. Invalid runs do not belong in `scientist-results.md`.

--- a/agents/strategist/role.md
+++ b/agents/strategist/role.md
@@ -19,7 +19,7 @@ This role is episodic. It is not a permanently polling terminal.
 
 You are invoked:
 
-- at the start of a run, before the supervisor writes the first serious scientist guidance
+- at the start of a run, before the supervisor posts the first serious scientist task
 - when the local date changes
 - after a meaningful leaderboard signal
 - after repeated plateau or exhaustion in the current lane
@@ -33,31 +33,32 @@ Authority model:
 
 ## Git Setup
 
-- **Branch:** `autokaggle/<tag>/supervisor`
-- **Directory:** `<root>/AutoKaggle/` (same repo as the supervisor; no separate worktree)
+- **Branch:** `run`
+- **Directory:** `<root>/AutoKaggle/` (same repo as the supervisor)
 - **Tracked files you own:** `agents/strategist/strategy-whitepaper.md`, `agents/strategist/strategy-idea-cookbook.md`
 
 ## Path Variables
 
-Define these once after setup is complete (substitute real values for `<root>` and `<tag>`):
+Define these once after setup is complete:
 
 ```bash
 REPO=<root>/AutoKaggle
 DATA=$REPO/data
-ARTIFACTS=$REPO/artifacts/<tag>
+ARTIFACTS=$REPO/artifacts
 ```
 
-Resolve these dynamically at runtime from your current branch and worktree layout. Do not commit machine-specific paths.
+Resolve these dynamically at runtime from your current checkout. Do not commit machine-specific paths.
 
 ## Setup
 
 On invocation:
 
-1. Confirm you are in `<root>/AutoKaggle/` on branch `autokaggle/<tag>/supervisor`
+1. Confirm you are in `<root>/AutoKaggle/` on branch `run`
 2. Reuse the current repo's local Claude settings if they already exist. If you need to create or update `.claude/settings.local.json` to read shared data or shared artifacts, ask the human once for permission first.
 3. Ensure the current repo can read the shared data and shared artifacts it needs
 4. Read the available strategy inputs listed below
 5. Compute the current date, deadline assumption, and days remaining before writing or refreshing the whitepaper
+6. Stop and leave strategist file changes for the supervisor to review and commit
 
 If you are invoked very early in the run and some evidence files do not exist yet, write the strongest strategy you can from the current date, the cookbook, `harness/dataset.py`, and `agents/scientist/experiment.py`, then note the missing inputs explicitly in `agents/strategist/strategy-whitepaper.md`.
 
@@ -113,6 +114,7 @@ Suggested phase taxonomy:
 - Install packages or modify dependencies
 - Submit to Kaggle
 - Act as a second supervisor
+- Commit tracked files
 
 ## Whitepaper Requirements
 

--- a/agents/supervisor/role.md
+++ b/agents/supervisor/role.md
@@ -15,21 +15,21 @@ Make the right calls at the right time: consume the strategist's long-horizon pl
 
 ## Git Setup
 
-- **Branch:** `autokaggle/<tag>/supervisor`
-- **Directory:** `<root>/AutoKaggle/` (the main repo; no separate worktree)
+- **Branch:** `run`
+- **Directory:** `<root>/AutoKaggle/` (the shared repo checkout)
 - **Tracked files you own:** `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, `agents/supervisor/leaderboard-history.md`, `agents/supervisor/submission.py`
 
 ## Path Variables
 
-Define these once after setup is complete (substitute real values for `<root>` and `<tag>`):
+Define these once after setup is complete:
 
 ```bash
 REPO=<root>/AutoKaggle
 DATA=$REPO/data
-ARTIFACTS=$REPO/artifacts/<tag>
+ARTIFACTS=$REPO/artifacts
 ```
 
-Resolve these dynamically at runtime from your current branch and worktree layout. Do not commit machine-specific paths.
+Resolve these dynamically at runtime from your current checkout. Do not commit machine-specific paths.
 
 ## Cross-Agent File Paths
 
@@ -57,10 +57,11 @@ Your own communication files live in `$REPO/agents/` and are read by the other a
 - Write `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, and `agents/supervisor/leaderboard-history.md`
 - Edit `agents/supervisor/submission.py` if the submission-preparation helper needs adjustment
 - Read and operationalize `agents/strategist/strategy-whitepaper.md`, but do not treat it as self-executing
-- Create branches, worktrees, and shared run directories
+- Create or update the long-lived `run` branch and shared runtime directories
 - Create or update `.claude/settings.local.json` in the current repo so you have the directories and permissions needed for this run
 - Run `harness/promotion_runner.py` to trigger submissions
 - Ask the human for any new package, permission, or capability you need
+- Commit tracked files after completed checkpoints
 
 **What you CANNOT do:**
 - Inspect raw dataset files directly or do EDA yourself
@@ -69,11 +70,19 @@ Your own communication files live in `$REPO/agents/` and are read by the other a
 - Treat strategist recommendations as direct instructions to other roles without translating them into operational guidance
 - Post open-ended analyst work. Every analyst request must be a yes/no question tied to a decision.
 
+## Commit Discipline
+
+- You are the only agent that commits tracked files.
+- Never commit while strategist, analyst, or scientist work is still in flight.
+- Prefer not to edit tracked files yourself while a subagent is running.
+- Before each commit, validate the tracked diff against role ownership. If a subagent touched files outside its allowed set, do not commit; send it back to fix the checkpoint first.
+- `agents/scientist/scientist-task.md` and `agents/analyst/analyst-hypothesis.md` are tracked live-control files. Do not commit them in an active state unless you are intentionally checkpointing a paused run. Normally clear them back to `status: none` before you commit.
+
 ---
 
 ## Phase 1: Setup
 
-This runs once, before the main loop. You start on the `main` branch in `<root>/AutoKaggle/`.
+This runs once, before the main loop. You start in `<root>/AutoKaggle/`, usually on `main`.
 
 ### 1. Bootstrap local Claude settings
 
@@ -81,37 +90,21 @@ Before any other setup work, ask the human once for permission to create or upda
 
 Use this local settings file to:
 
-- grant yourself the exact Bash permissions needed for git, worktree, data bootstrap, and submission work
-- add sibling worktrees, shared data, and shared artifacts under `permissions.additionalDirectories`
+- grant yourself the exact Bash permissions needed for git, data bootstrap, and submission work
+- add shared data and shared artifacts under `permissions.additionalDirectories`
 - keep machine-specific full filesystem paths out of committed files
 
 After editing local settings, run `/status` and confirm the local settings layer is active. If `/loop` is unavailable, scheduled tasks are disabled, or Claude Code is too old to support scheduled tasks, tell the human immediately before continuing.
 
-### 2. Propose a run tag
+### 2. Create or update the `run` branch
 
-Check existing branches to avoid collisions:
-
-```bash
-git branch | grep autokaggle/
-```
-
-Propose a tag based on today's date (for example `apr5`). Present it to the human and **wait for confirmation** before proceeding. The human may want a different tag.
-
-### 3. Create the supervisor branch
-
-Once the tag is confirmed:
+Switch to the long-lived run branch:
 
 ```bash
-TAG=<confirmed-tag>
-
-# Create the persistent-role branch from main
-git branch autokaggle/$TAG/supervisor main
-
-# Check out your own branch in the current directory
-git checkout autokaggle/$TAG/supervisor
+git checkout run || git checkout -b run
 ```
 
-### 4. Ensure data is available
+### 3. Ensure data is available
 
 ```bash
 ls data/train.csv data/test.csv 2>/dev/null
@@ -125,35 +118,35 @@ uv run python -m harness.dataset
 
 This downloads competition data and generates `data/folds.csv`. If it fails due to missing Kaggle credentials or competition access, escalate to the human immediately. The run cannot proceed without data.
 
-### 5. Create the artifacts directory
+### 4. Create the artifacts directory
 
 ```bash
-mkdir -p artifacts/$TAG
+mkdir -p artifacts/experiments
 ```
 
-### 6. Initialise communication files
+### 5. Initialise missing communication files
 
-Create and commit your tracked coordination files with placeholder headers:
+Ensure the tracked coordination files exist. Do not wipe existing histories on the `run` branch:
 
 ```bash
-cat > agents/scientist/scientist-task.md <<'EOF'
+test -f agents/scientist/scientist-task.md || cat > agents/scientist/scientist-task.md <<'EOF'
 # Active Scientist Task
 status: none
 EOF
-cat > agents/scientist/scientist-results.md <<'EOF'
+test -f agents/scientist/scientist-results.md || cat > agents/scientist/scientist-results.md <<'EOF'
 # Scientist Results
 
 | id | code | status | score | std | delta_best | desc |
 |----|------|--------|-------|-----|------------|------|
 EOF
-echo "# Scientist Knowledge" > agents/scientist/scientist-knowledge.md
-cat > agents/analyst/analyst-hypothesis.md <<'EOF'
+test -f agents/scientist/scientist-knowledge.md || echo "# Scientist Knowledge" > agents/scientist/scientist-knowledge.md
+test -f agents/analyst/analyst-hypothesis.md || cat > agents/analyst/analyst-hypothesis.md <<'EOF'
 # Active Analyst Hypothesis
 status: none
 EOF
-echo "# Analyst Findings" > agents/analyst/analyst-findings.md
-echo "# Analyst Knowledge" > agents/analyst/analyst-knowledge.md
-cat > agents/supervisor/leaderboard-history.md <<'EOF'
+test -f agents/analyst/analyst-findings.md || echo "# Analyst Findings" > agents/analyst/analyst-findings.md
+test -f agents/analyst/analyst-knowledge.md || echo "# Analyst Knowledge" > agents/analyst/analyst-knowledge.md
+test -f agents/supervisor/leaderboard-history.md || cat > agents/supervisor/leaderboard-history.md <<'EOF'
 # Leaderboard History
 
 ## Submission Ledger
@@ -167,23 +160,23 @@ cat > agents/supervisor/leaderboard-history.md <<'EOF'
 EOF
 
 git add agents/scientist/scientist-task.md agents/scientist/scientist-results.md agents/scientist/scientist-knowledge.md agents/analyst/analyst-hypothesis.md agents/analyst/analyst-findings.md agents/analyst/analyst-knowledge.md agents/supervisor/leaderboard-history.md
-git commit -m "init: supervisor communication files for $TAG"
+git diff --cached --quiet || git commit -m "init: run branch coordination files"
 ```
 
-### 7. Obtain the initial strategy whitepaper
+### 6. Obtain the initial strategy whitepaper
 
 Before the run goes live, ensure `agents/strategist/strategy-whitepaper.md` exists and is current.
 
 Prefer invoking the strategist role on demand in the current repo. If episodic strategist invocation is unavailable, ask the human to open a temporary strategist session in the current repo and point it at `agents/strategist/role.md`.
 
-Do not write serious scientist guidance until you have a strategy whitepaper for the current date.
+Do not post serious scientist tasks until you have a strategy whitepaper for the current date.
 
-### 8. Start the run
+### 7. Start the run
 
 No other persistent terminal is required.
 
 ```text
-Setup complete for run: <tag>
+Setup complete on branch: run
 
 I will invoke strategist, analyst, and scientist work on demand in <root>/AutoKaggle/ when needed.
 If direct episodic invocation is unavailable, I may ask you to open a temporary strategist, analyst, or scientist session in the main repo. Those are not permanent terminals.
@@ -195,10 +188,10 @@ If direct episodic invocation is unavailable, I may ask you to open a temporary 
 3. Post an initial analyst hypothesis only if you already need analyst evidence, then invoke the analyst.
 4. Review agents/supervisor/leaderboard-history.md before spending any submission budget.
 5. Create a recurring /loop 5m task for yourself, for example:
-   /loop 5m Review agents/strategist/strategy-whitepaper.md and agents/supervisor/leaderboard-history.md. If scientist work completed since your last review, also read agents/scientist/scientist-results.md and agents/scientist/scientist-knowledge.md. If analyst work completed since your last review, also read agents/analyst/analyst-findings.md and agents/analyst/analyst-knowledge.md. If there is new information since your last review, refresh strategy when needed, post or clear scientist and analyst requests, invoke episodic work when warranted, submit when warranted, commit any changed files, and leave the human a concise status note. Otherwise report that no changes were needed.
+   /loop 5m Review agents/strategist/strategy-whitepaper.md and agents/supervisor/leaderboard-history.md. If scientist work completed since your last review, also read agents/scientist/scientist-results.md and agents/scientist/scientist-knowledge.md. If analyst work completed since your last review, also read agents/analyst/analyst-findings.md and agents/analyst/analyst-knowledge.md. If there is new information since your last review, refresh strategy when needed, post or clear scientist and analyst requests, invoke episodic work when warranted, submit when warranted, commit only if no subagent is active, and leave the human a concise status note. Otherwise report that no changes were needed.
 ```
 
-Write the initial `agents/scientist/scientist-task.md` only when there is concrete experiment work to run. Use `harness/dataset.py` and `agents/scientist/experiment.py` to ground the task in the current evaluation contract and baseline implementation. Commit it. The run has begun.
+Write the initial `agents/scientist/scientist-task.md` only when there is concrete experiment work to run. Use `harness/dataset.py` and `agents/scientist/experiment.py` to ground the task in the current evaluation contract and baseline implementation. Do not commit an active task file. The run has begun.
 
 ---
 
@@ -225,7 +218,7 @@ You wake on a recurring `/loop 5m` task plus human input. On each wake:
 
 5. Decide and act (see decisions below)
 
-6. Commit any files you updated.
+6. If no subagent is active, validate and commit any completed checkpoint files.
 
 7. Report to the human (see human communication below)
 ```
@@ -271,7 +264,8 @@ After posting the task:
 2. If direct episodic invocation is unavailable, ask the human to open a temporary scientist session in `$REPO/` and tell it to follow `agents/scientist/role.md`.
 3. Tell it to read `agents/program.md`, `agents/scientist/role.md`, `agents/scientist/scientist-knowledge.md`, and `agents/scientist/scientist-task.md`.
 4. Wait for a new appended entry in `agents/scientist/scientist-results.md` before replacing the task with a different one.
-5. After the experiment completes, read the new result and refreshed scientist knowledge, make the next decision, then reset `agents/scientist/scientist-task.md` to `status: none`.
+5. Do not commit while the scientist is running.
+6. After the experiment completes, read the new result and refreshed scientist knowledge, make the next decision, then reset `agents/scientist/scientist-task.md` to `status: none`.
 
 ### Post to agents/analyst/analyst-hypothesis.md and invoke analyst work
 
@@ -298,7 +292,19 @@ After posting the hypothesis:
 2. If direct episodic invocation is unavailable, ask the human to open a temporary analyst session in `$REPO/` and tell it to follow `agents/analyst/role.md`.
 3. Tell it to read `agents/program.md`, `agents/analyst/role.md`, `agents/analyst/analyst-knowledge.md`, and `agents/analyst/analyst-hypothesis.md`.
 4. Wait for a new appended entry in `agents/analyst/analyst-findings.md` before replacing the hypothesis with a different one.
-5. After the investigation completes, read the new finding and refreshed knowledge, make the blocked decision, then reset `agents/analyst/analyst-hypothesis.md` to `status: none`.
+5. Do not commit while the analyst is running.
+6. After the investigation completes, read the new finding and refreshed knowledge, make the blocked decision, then reset `agents/analyst/analyst-hypothesis.md` to `status: none`.
+
+### Commit a checkpoint
+
+Commit only when strategist, analyst, and scientist are all idle.
+
+Before committing:
+
+1. Run `git diff --name-only` and verify the tracked changes match role ownership.
+2. If a subagent changed tracked files outside its allowed set, do not commit. Send it back to fix the checkpoint first.
+3. Clear `agents/scientist/scientist-task.md` and `agents/analyst/analyst-hypothesis.md` back to `status: none` unless you are intentionally recording a paused active state.
+4. Commit the completed checkpoint with a message that describes the completed work, not the temporary control-file state.
 
 ### Update agents/supervisor/leaderboard-history.md
 
@@ -342,7 +348,6 @@ Workflow:
 3. Run harness/promotion_runner.py:
    uv run python -m harness.promotion_runner \
      --hash <hash> \
-     --tag <tag> \
      --artifact-dir $ARTIFACTS/experiments/<hash> \
      --cv-score <cv_score>
 4. Consume the JSON result from the harness. It validates the artifact, generates submission.csv if needed, submits to Kaggle, polls until scored or timeout/error, and returns fields such as submitted_at, submission_id, terminal_status, lb_score, lb_rank when available, and error_category on failure.

--- a/harness/experiment_runner.py
+++ b/harness/experiment_runner.py
@@ -4,7 +4,6 @@ import importlib.util
 import multiprocessing as mp
 import os
 import queue
-import subprocess
 import sys
 import time
 import traceback
@@ -22,13 +21,6 @@ INVALID_EXIT_CODE = 2
 def main() -> None:
     args = _parse_args()
     experiment_path = _normalize_repo_path(args.experiment_path)
-    editable_path = _normalize_repo_path(args.editable_path or args.experiment_path)
-
-    try:
-        _enforce_edit_boundary(editable_path)
-    except RuntimeError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        raise SystemExit(1) from exc
 
     total_start = time.perf_counter()
     deadline = time.monotonic() + TIME_BUDGET_SECONDS
@@ -166,33 +158,10 @@ def _run_evaluation(messages: mp.Queue, experiment_path: Path) -> None:
         )
 
 
-def _enforce_edit_boundary(editable_path: Path) -> None:
-    if os.environ.get("AUTOKAGGLE_STRICT_EDIT_GUARD") != "1":
-        return
-
-    allowed_path = _to_repo_relative_path(editable_path)
-    changed_paths: set[str] = set()
-    commands = (
-        ["git", "diff", "--name-only"],
-        ["git", "diff", "--cached", "--name-only"],
-    )
-    for command in commands:
-        completed = subprocess.run(command, check=True, capture_output=True, text=True)
-        changed_paths.update(Path(line.strip()).as_posix() for line in completed.stdout.splitlines() if line.strip())
-
-    disallowed = sorted(path for path in changed_paths if path != allowed_path)
-    if disallowed:
-        joined = ", ".join(disallowed)
-        raise RuntimeError(
-            f"tracked edits outside {allowed_path} are not allowed during experiment runs: {joined}"
-        )
-
-
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--experiment-path", type=Path, default=DEFAULT_EXPERIMENT_PATH)
-    parser.add_argument("--editable-path", type=Path)
     return parser.parse_args()
 
 
@@ -261,14 +230,6 @@ def _normalize_repo_path(path: Path) -> Path:
     if path.is_absolute():
         return path.resolve()
     return (REPO_ROOT / path).resolve()
-
-
-def _to_repo_relative_path(path: Path) -> str:
-    resolved = _normalize_repo_path(path)
-    try:
-        return resolved.relative_to(REPO_ROOT).as_posix()
-    except ValueError:
-        return resolved.as_posix()
 
 
 def _load_module_from_path(module_path: Path, module_name: str):

--- a/harness/promotion_runner.py
+++ b/harness/promotion_runner.py
@@ -62,7 +62,6 @@ T = TypeVar("T")
 @dataclass
 class PromotionResult:
     hash: str
-    tag: str
     competition: str
     artifact_dir: str
     submission_file: str
@@ -98,11 +97,10 @@ def main() -> None:
 
 
 def _run_promotion(args: argparse.Namespace) -> PromotionResult:
-    artifact_dir = _normalize_repo_path(args.artifact_dir or _default_artifact_dir(args.tag, args.hash))
+    artifact_dir = _normalize_repo_path(args.artifact_dir or _default_artifact_dir(args.hash))
     submission_file = _normalize_repo_path(args.submission_file or artifact_dir / DEFAULT_SUBMISSION_FILENAME)
     result = PromotionResult(
         hash=args.hash,
-        tag=args.tag,
         competition=COMPETITION,
         artifact_dir=str(artifact_dir),
         submission_file=str(submission_file),
@@ -220,7 +218,6 @@ def _run_promotion(args: argparse.Namespace) -> PromotionResult:
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--hash", required=True)
-    parser.add_argument("--tag", required=True)
     parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--submission-file", type=Path)
     parser.add_argument("--cv-score", type=float)
@@ -473,8 +470,8 @@ def _is_transient_kaggle_error(exc: Exception) -> bool:
     return any(token in message for token in TRANSIENT_KAGGLE_TOKENS)
 
 
-def _default_artifact_dir(tag: str, hash_value: str) -> Path:
-    return DEFAULT_ARTIFACTS_ROOT / tag / "experiments" / hash_value
+def _default_artifact_dir(hash_value: str) -> Path:
+    return DEFAULT_ARTIFACTS_ROOT / "experiments" / hash_value
 
 
 def _normalize_repo_path(path: Path) -> Path:

--- a/tests/test_promotion_runner.py
+++ b/tests/test_promotion_runner.py
@@ -103,8 +103,6 @@ class PromotionRunnerTests(unittest.TestCase):
                     "promotion_runner",
                     "--hash",
                     hash_value,
-                    "--tag",
-                    "mar28",
                     "--artifact-dir",
                     str(artifact_dir),
                     "--cv-score",
@@ -151,8 +149,6 @@ class PromotionRunnerTests(unittest.TestCase):
                     "promotion_runner",
                     "--hash",
                     hash_value,
-                    "--tag",
-                    "mar28",
                     "--artifact-dir",
                     str(artifact_dir),
                     "--timeout-seconds",
@@ -181,8 +177,6 @@ class PromotionRunnerTests(unittest.TestCase):
                     "promotion_runner",
                     "--hash",
                     hash_value,
-                    "--tag",
-                    "mar28",
                     "--artifact-dir",
                     str(artifact_dir),
                 ],
@@ -213,6 +207,12 @@ class PromotionRunnerTests(unittest.TestCase):
             )
 
         self.assertEqual(rank, 3)
+
+    def test_default_artifact_dir_is_tag_free(self) -> None:
+        self.assertEqual(
+            promotion_runner._default_artifact_dir("abcdef1"),
+            Path("artifacts/experiments/abcdef1"),
+        )
 
     def _run_main(
         self,


### PR DESCRIPTION
## Summary
- remove worktree and run-tag assumptions from the shared docs and role contracts
- make the supervisor the only committer and document quiescent-point checkpointing
- remove the runner-side strict edit guard and make promotion artifact paths tag-free

## Testing
- uv run python -m unittest tests.test_experiment_runner tests.test_scientist_runner tests.test_analysis_runner tests.test_promotion_runner

Closes #24