### PR TITLE
Redesign strategist lifecycle and request flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The human is expected to:
 
 Useful places to inspect:
 
+- [agents/strategist/strategy-lifecycle-guide.md](agents/strategist/strategy-lifecycle-guide.md)
+- [agents/strategist/strategy-request.md](agents/strategist/strategy-request.md) when present
 - [agents/strategist/strategy-whitepaper.md](agents/strategist/strategy-whitepaper.md) when present
 - [agents/strategist/strategy-idea-cookbook.md](agents/strategist/strategy-idea-cookbook.md)
 - [agents/scientist/scientist-task.md](agents/scientist/scientist-task.md) when present
@@ -100,8 +102,10 @@ Useful places to inspect:
 Key tracked files:
 
 - [agents/program.md](agents/program.md): shared agent contract
+- [agents/strategist/strategy-lifecycle-guide.md](agents/strategist/strategy-lifecycle-guide.md): strategist-owned macro guide
+- [agents/strategist/strategy-request.md](agents/strategist/strategy-request.md): supervisor-owned factual strategist input
 - [agents/strategist/strategy-whitepaper.md](agents/strategist/strategy-whitepaper.md): strategist-owned current plan
-- [agents/strategist/strategy-idea-cookbook.md](agents/strategist/strategy-idea-cookbook.md): strategist-owned reusable playbook
+- [agents/strategist/strategy-idea-cookbook.md](agents/strategist/strategy-idea-cookbook.md): strategist-owned reusable idea bank
 - [agents/scientist/scientist-task.md](agents/scientist/scientist-task.md): supervisor-owned active scientist task
 - [agents/scientist/scientist-results.md](agents/scientist/scientist-results.md): append-only scientist result history
 - [agents/scientist/scientist-knowledge.md](agents/scientist/scientist-knowledge.md): concise scientist-owned durable memory

--- a/agents/program.md
+++ b/agents/program.md
@@ -26,7 +26,7 @@ Persistent roles:
 
 Episodic roles:
 
-- **Strategist** — long-horizon planning role. Produces `agents/strategist/strategy-whitepaper.md` and maintains `agents/strategist/strategy-idea-cookbook.md`. The strategist recommends; the supervisor decides.
+- **Strategist** — long-horizon planning role. Produces `agents/strategist/strategy-whitepaper.md`, maintains `agents/strategist/strategy-lifecycle-guide.md` and `agents/strategist/strategy-idea-cookbook.md`, and reads the supervisor-owned `agents/strategist/strategy-request.md`. The strategist recommends; the supervisor decides.
 - **Analyst** — signal quality expert. Invoked by the supervisor only when there is a concrete yes/no hypothesis to test. Inspects model artifacts and data, appends a durable findings entry, updates concise durable knowledge when warranted, then exits or idles until the next request.
 - **Scientist** — experiment engine. Invoked by the supervisor only when there is one concrete experiment task to execute. Implements one experiment, retries invalid launches locally, records one terminal result, updates concise durable knowledge when warranted, then exits.
 
@@ -37,7 +37,11 @@ Episodic roles:
 - The supervisor coordinates strategy and owns submission timing, submission notes, and leaderboard bookkeeping.
 - The supervisor does not inspect raw dataset files itself. If it needs dataset evidence, it asks the analyst.
 - The supervisor should treat unverified empirical claims as hypotheses. If a claim is decision-relevant and not already supported by experiment results, leaderboard history, or analyst output, route it to the analyst before acting on it.
+- The supervisor owns `agents/strategist/strategy-request.md`. The request is factual. The whitepaper is interpretive.
 - The strategist recommends the high-level plan. The supervisor translates that plan into operational guidance for the scientist and the rest of the team.
+- The strategist normally reads the strategy request, durable analyst knowledge, durable scientist knowledge, and leaderboard history. It does not need to reread raw findings and result histories on every refresh.
+- Early thin coverage is a strategy problem even if current CV is improving.
+- When time is abundant, no major cookbook area should remain completely untested.
 - The analyst is on-demand. It is invoked only for concrete decision-relevant hypotheses and does not require a standing terminal or polling loop.
 - The analyst answers one active, falsifiable hypothesis at a time. Hypotheses should be yes/no questions tied to a concrete decision.
 - The analyst presents evidence in code, tables, counts, and metrics. Findings should stay neutral and factual. Do not use plots unless the human explicitly asks.
@@ -78,6 +82,8 @@ Episodic roles:
         submission.py                # supervisor-owned submission prep helper
       strategist/
         role.md
+        strategy-lifecycle-guide.md
+        strategy-request.md          # supervisor-owned factual strategist input
         strategy-whitepaper.md
         strategy-idea-cookbook.md
       analyst/
@@ -111,15 +117,16 @@ All inter-agent coordination flows through tracked files in the repository, read
 
 | File | Owned by | Read by | Lives in |
 |------|----------|---------|----------|
+| `agents/strategist/strategy-request.md` | Supervisor | Strategist | `AutoKaggle/` |
 | `agents/strategist/strategy-whitepaper.md` | Strategist | Supervisor | `AutoKaggle/` |
 | `agents/strategist/strategy-idea-cookbook.md` | Strategist | Strategist, Supervisor | `AutoKaggle/` |
 | `agents/scientist/scientist-task.md` | Supervisor | Scientist | `AutoKaggle/` |
 | `agents/analyst/analyst-hypothesis.md` | Supervisor | Analyst | `AutoKaggle/` |
-| `agents/analyst/analyst-findings.md` | Analyst | Supervisor, Strategist | `AutoKaggle/` |
-| `agents/analyst/analyst-knowledge.md` | Analyst | Analyst, Supervisor | `AutoKaggle/` |
+| `agents/analyst/analyst-findings.md` | Analyst | Supervisor | `AutoKaggle/` |
+| `agents/analyst/analyst-knowledge.md` | Analyst | Analyst, Supervisor, Strategist | `AutoKaggle/` |
 | `agents/supervisor/leaderboard-history.md` | Supervisor | Supervisor, Strategist | `AutoKaggle/` |
-| `agents/scientist/scientist-results.md` | Scientist | Supervisor, Analyst, Strategist | `AutoKaggle/` |
-| `agents/scientist/scientist-knowledge.md` | Scientist | Scientist, Supervisor | `AutoKaggle/` |
+| `agents/scientist/scientist-results.md` | Scientist | Supervisor, Analyst | `AutoKaggle/` |
+| `agents/scientist/scientist-knowledge.md` | Scientist | Scientist, Supervisor, Strategist | `AutoKaggle/` |
 
 Binary artifacts (`oof-preds.npy`, `model.pkl`, `test-preds.npy`) are never committed. They live in `AutoKaggle/artifacts/experiments/<hash>/` and are accessed by all agents via absolute path. Per-run logs and exit-code files may live beside them as untracked local runtime state.
 
@@ -133,7 +140,7 @@ Binary artifacts (`oof-preds.npy`, `model.pkl`, `test-preds.npy`) are never comm
 
 CV score is the default local optimisation metric, but it is not the sole objective. The supervisor may deliberately direct work toward simpler models, a stronger linear component, or a complementary model family for later ensembling. The supervisor tracks whether CV gains translate to LB gains in `agents/supervisor/leaderboard-history.md`. If they stop correlating, treat this as a priority signal over chasing further CV improvement.
 
-The strategist decides the current phase using the current date, the competition deadline assumption, and the evidence accumulated so far. The whitepaper should explicitly state the current date, the deadline assumption, and the number of calendar days remaining using absolute dates.
+The supervisor refreshes `agents/strategist/strategy-request.md` from factual run state and durable knowledge. The strategist then computes the current date, the deadline assumption, the number of calendar days remaining, and the current emphasis across the full cycle. The whitepaper should explicitly state the current date, the deadline assumption, and the number of calendar days remaining using absolute dates.
 
 ### Experimentation
 

--- a/agents/strategist/role.md
+++ b/agents/strategist/role.md
@@ -1,6 +1,6 @@
 # Strategist
 
-The strategist is the long-horizon planning role. Your job is to translate the current competition date, remaining submission budget, and accumulated run evidence into a concrete plan for the rest of the month.
+The strategist is the long-horizon planning role. Your job is to translate the current competition date, the deadline assumption, the supervisor's factual snapshot, durable analyst and scientist knowledge, and leaderboard behavior into a concrete plan for the rest of the competition.
 
 ## Audience
 
@@ -11,7 +11,12 @@ This document is read by the strategist agent only.
 
 ## Goal
 
-Produce a deadline-aware `agents/strategist/strategy-whitepaper.md` that the supervisor can translate into operational guidance for the scientist. Maintain a reusable `agents/strategist/strategy-idea-cookbook.md` so strategy is chosen from evidence-backed plays rather than improvised from scratch each run.
+Produce a deadline-aware `agents/strategist/strategy-whitepaper.md` that the supervisor can translate into operational guidance. Maintain two reusable strategist references:
+
+- `agents/strategist/strategy-lifecycle-guide.md` for the macro cycle and emphasis model
+- `agents/strategist/strategy-idea-cookbook.md` for the long list of strategy possibilities
+
+The whitepaper is run-specific. The lifecycle guide and cookbook are reusable.
 
 ## Role Shape
 
@@ -22,8 +27,8 @@ You are invoked:
 - at the start of a run, before the supervisor posts the first serious scientist task
 - when the local date changes
 - after a meaningful leaderboard signal
-- after repeated plateau or exhaustion in the current lane
-- whenever the supervisor explicitly asks for a strategic refresh
+- when the supervisor wants a strategic refresh
+- when the supervisor believes coverage, pace, or emphasis may need to change
 
 Authority model:
 
@@ -35,7 +40,7 @@ Authority model:
 
 - **Branch:** `run`
 - **Directory:** `<root>/AutoKaggle/` (same repo as the supervisor)
-- **Tracked files you own:** `agents/strategist/strategy-whitepaper.md`, `agents/strategist/strategy-idea-cookbook.md`
+- **Tracked files you own:** `agents/strategist/strategy-whitepaper.md`, `agents/strategist/strategy-lifecycle-guide.md`, `agents/strategist/strategy-idea-cookbook.md`
 
 ## Path Variables
 
@@ -55,26 +60,32 @@ On invocation:
 
 1. Confirm you are in `<root>/AutoKaggle/` on branch `run`
 2. Reuse the current repo's local Claude settings if they already exist. If you need to create or update `.claude/settings.local.json` to read shared data or shared artifacts, ask the human once for permission first.
-3. Ensure the current repo can read the shared data and shared artifacts it needs
-4. Read the available strategy inputs listed below
-5. Compute the current date, deadline assumption, and days remaining before writing or refreshing the whitepaper
+3. Read the available strategy inputs listed below
+4. Compute the current date, deadline assumption, and days remaining
+5. Refresh `agents/strategist/strategy-whitepaper.md`
 6. Stop and leave strategist file changes for the supervisor to review and commit
-
-If you are invoked very early in the run and some evidence files do not exist yet, write the strongest strategy you can from the current date, the cookbook, `harness/dataset.py`, and `agents/scientist/experiment.py`, then note the missing inputs explicitly in `agents/strategist/strategy-whitepaper.md`.
 
 ## Inputs
 
 Read what you need from:
 
 ```text
+$REPO/agents/strategist/strategy-lifecycle-guide.md
 $REPO/agents/strategist/strategy-idea-cookbook.md
-$REPO/agents/scientist/scientist-results.md
-$REPO/agents/scientist/scientist-task.md
-$REPO/agents/analyst/analyst-findings.md
+$REPO/agents/strategist/strategy-request.md
+$REPO/agents/analyst/analyst-knowledge.md
+$REPO/agents/scientist/scientist-knowledge.md
 $REPO/agents/supervisor/leaderboard-history.md
+```
+
+Optional reads when you genuinely need them:
+
+```text
 $REPO/harness/dataset.py
 $REPO/agents/scientist/experiment.py
 ```
+
+Do not normally read raw analyst findings or raw scientist result history. The supervisor should distill factual run state and durable knowledge into `agents/strategist/strategy-request.md`.
 
 You may also read the current date from the environment or shell.
 
@@ -86,30 +97,19 @@ Always write dates explicitly. Use absolute dates such as `March 31, 2026`, not 
 
 Example: if the current date is `March 28, 2026` and the deadline assumption is `March 31, 2026`, write `Days Remaining: 3`.
 
-Your whitepaper must state:
-
-- the current date
-- the deadline assumption
-- the number of calendar days remaining
-
-Suggested phase taxonomy:
-
-- bootstrap / anchor-finding
-- broad exploration
-- narrowing / evidence gathering
-- exploitation / shortlist building
-- final submission discipline
+Use `agents/strategist/strategy-lifecycle-guide.md` as a soft emphasis model, not as a rigid quota system. The strategist may deviate from the default emphasis profile when the run state justifies it, but should explain the deviation in the whitepaper.
 
 ## Boundaries
 
 **What you CAN do:**
-- Read experiment history, findings, leaderboard history, and shared competition metadata
+- Read the strategy request, durable knowledge files, leaderboard history, and shared competition metadata
 - Write `agents/strategist/strategy-whitepaper.md`
+- Curate and improve `agents/strategist/strategy-lifecycle-guide.md`
 - Curate and improve `agents/strategist/strategy-idea-cookbook.md`
 - Ask the human for any new permission or capability you need
 
 **What you CANNOT do:**
-- Edit `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, or `agents/supervisor/leaderboard-history.md`
+- Edit `agents/strategist/strategy-request.md`, `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, or `agents/supervisor/leaderboard-history.md`
 - Inspect raw dataset files directly or do EDA yourself
 - Install packages or modify dependencies
 - Submit to Kaggle
@@ -132,57 +132,56 @@ Write `agents/strategist/strategy-whitepaper.md` in this shape:
 ## Days Remaining
 <integer calendar days remaining>
 
-## Current Phase
-<one of the documented phase labels, with a short explanation>
+## Read
+<concise read of coverage, pace, and current run shape>
 
-## Submission Budget Posture
-<how aggressively or conservatively the remaining submissions should be used>
+## Emphasis
+Primary: <what should dominate now>
+Secondary: <what should stay materially active>
+Background: <what should keep moving lightly>
+Hold: <what should stay quiet for now>
 
-## Strategic Objective
-<what the team should optimize for over the remaining time>
-
-## Recommended Allocation
-- Strong single-model baselines: <percentage or rough share>
-- Diversity-building models: <percentage or rough share>
-- Ensembling: <percentage or rough share>
-- Diagnostics / analysis: <percentage or rough share>
-- Leaderboard validation: <percentage or rough share>
-
-## Immediate Guidance For The Supervisor
+## Guidance For The Supervisor
 1. <first recommendation>
 2. <second recommendation>
+3. <third recommendation if needed>
 
-## Priority Plays From The Cookbook
-- <play name> - <why now>
-- <play name> - <why now>
-
-## Deprioritize For Now
-- <what not to spend time on right now>
-
-## Pivot Conditions
-- <condition that should trigger a strategy refresh>
-- <condition that should trigger a strategy refresh>
-
-## Why
-<brief synthesis of the evidence behind the plan>
+## Refresh Triggers
+- <condition>
+- <condition>
 ```
+
+The whitepaper should keep the full cycle alive. It should state what deserves the most attention now, not pretend the rest of the cycle disappeared.
+
+## Lifecycle Guide Maintenance
+
+`agents/strategist/strategy-lifecycle-guide.md` is the reusable macro guide.
+
+Keep it short. It should describe:
+
+- the canonical cycle
+- the default emphasis profile across the competition
+- pace modifiers
+- anti-rushing guardrails
+
+It should not become a run log.
 
 ## Cookbook Maintenance
 
-`agents/strategist/strategy-idea-cookbook.md` is a reusable planning artifact, not a run log.
+`agents/strategist/strategy-idea-cookbook.md` is the reusable strategy bank.
 
-Update it when:
+Keep it broad, inspiration-oriented, and cumulative.
 
-- you learn something reusable about when a strategy works
-- a play should be demoted because repeated evidence shows it is low-value
-- the cookbook is missing an important family of options
-
-Do not rewrite the whole cookbook every run. Keep it stable and cumulative.
+- It should be a long list of possibilities, not a ranking system.
+- It should group ideas loosely so major areas are easy to scan.
+- It should not decide timing or priority on its own.
+- No major cookbook area should remain completely untested when time is abundant.
 
 ## What Good Strategy Looks Like
 
-- **Deadline-aware.** Early-month advice and late-month advice should not look the same.
-- **Budget-aware.** Submission policy should tighten as the deadline approaches.
+- **Deadline-aware.** Early and late advice should not look the same.
+- **Coverage-aware.** Thin foundation early is a strategy problem even if current CV is improving.
 - **Lane-setting, not code-writing.** Recommend what kinds of work the supervisor should direct, not line-by-line implementation details.
-- **Evidence-backed.** Use experiment history, analysis findings, and LB behavior explicitly.
-- **Conservative when time is short.** Near the deadline, favor reproducible high-confidence plays over speculative breadth.
+- **Evidence-backed.** Use the request, durable knowledge, and leaderboard behavior explicitly.
+- **Broad when time is abundant.** Do not let strong early anchors collapse the search space too fast.
+- **Compressed, not amputated, when time is short.** Late pressure narrows emphasis but does not erase parts of the cycle.

--- a/agents/strategist/strategy-idea-cookbook.md
+++ b/agents/strategist/strategy-idea-cookbook.md
@@ -2,296 +2,180 @@
 
 This file is owned by the strategist role.
 
-It is a reusable menu of strategic plays. It should remain broadly useful across runs and should not turn into a run-specific journal.
-
-For each play, state:
-
-- when to use it
-- why it might help
-- what evidence should justify trying it
-- what evidence should cause it to be deprioritized
-
-## Baseline Anchors
-
-### Simple linear baseline
-
-- When to use it: at the very start of a run or when the team needs a reproducible sanity anchor
-- Why it might help: establishes a trustworthy floor and exposes whether the feature space is already strong
-- Try it if: there is no anchor yet or the scientist has drifted too quickly into complexity
-- Deprioritize if: a solid anchor already exists and later work is clearly above it
-
-### Regularized linear variants
-
-- When to use it: after the basic linear anchor is in place
-- Why it might help: can improve calibration, robustness, or future ensemble value with low complexity
-- Try it if: the strategy calls for a stronger linear component or a simple ensemble ingredient
-- Deprioritize if: repeated linear variants produce no meaningful movement
-
-### First strong tree baseline
-
-- When to use it: early, once the simplest anchor exists
-- Why it might help: quickly establishes the likely single-model strength of the tabular problem
-- Try it if: the team needs to know whether tree models are the primary frontier
-- Deprioritize if: the frontier has already moved to refinement or late-phase discipline
-
-## Stronger Single-Model Families
-
-### LightGBM / XGBoost refinement
-
-- When to use it: once a tree anchor exists and there is evidence that a single model can still move materially
-- Why it might help: these models often provide the strongest single-model performance on tabular Playground tasks
-- Try it if: the team still lacks a strong leaderboard anchor or the current best single model is not yet convincing
-- Deprioritize if: late-stage work favors shortlist stability over more tree tuning
-
-### CatBoost / native categoricals
-
-- When to use it: when the feature mix suggests categorical handling may be decisive
-- Why it might help: can unlock signal where one-hot approaches are brittle or lossy
-- Try it if: analysis shows categorical structure is central or native-cat trials have promise
-- Deprioritize if: repeated evidence shows native categorical handling is worse on this competition
-
-### CatBoost tuned for divergence (not just strength)
-
-- When to use it: when CatBoost default is already in the shortlist but ensemble gain is small because it is too correlated with LGBM
-- Why it might help: CatBoost at default settings often follows similar gradient contours to LGBM. Lower learning rate (0.03), more iterations (1500–2000), higher depth (8–10), and feature subsampling (rsm=0.7) can push CatBoost into different feature interactions, making it a more useful ensemble partner
-- Try it if: LGBM+CatBoost ensemble adds less than +0.001 LB over LGBM alone — this is a sign of correlation, not complementarity
-- Deprioritize if: tuned CatBoost still tracks LGBM closely in CV (difference < 0.0003 in ensemble gain)
-
-### Reweighted or calibrated variants
-
-- When to use it: when imbalance, calibration drift, or threshold behavior may matter
-- Why it might help: can improve ranking quality or make a model more ensemble-friendly
-- Try it if: analysis highlights class imbalance or unreliable probability shape
-- Deprioritize if: the metric is insensitive and the modifications consistently fail
-
-## Diversity-Building Plays
-
-### Model-family diversification
-
-- When to use it: after at least one strong anchor exists
-- Why it might help: different model families can add ensemble value even when their standalone CV is slightly worse
-- Try it if: the strategy objective includes future ensembling or the current best family appears exhausted
-- Deprioritize if: time is short and there is no realistic path to using the diversity
-
-### ExtraTrees / Random Forest as bagging-family diversity component
-
-- When to use it: when LGBM and CatBoost are both in the shortlist but ensemble gain is small due to high correlation between two boosting-family models
-- Why it might help: bagging models (ExtraTrees, RandomForest) have structurally different error patterns from boosting models. They reduce variance through averaging independently-grown trees rather than through sequential correction of residuals. This makes them naturally more orthogonal to LGBM/CatBoost even when their standalone CV is somewhat lower
-- Try it if: LGBM+CatBoost correlation is high (ensemble gain < +0.001 LB) and there is still time for a diversity experiment
-- Deprioritize if: ensemble gain from adding the bagging component is still negligible after tuning, or if the standalone CV is more than 0.003 below the best boosting model (the diversity gain rarely overcomes that gap)
-- Suggested starting point: ExtraTreesClassifier n_estimators=500, max_features="sqrt", min_samples_leaf=5; or RandomForestClassifier with similar settings
-
-### Feature-space diversification
-
-- When to use it: when multiple credible preprocessing routes exist
-- Why it might help: different feature constructions can create complementary errors
-- Try it if: analysis suggests alternative representations may capture different structure
-- Deprioritize if: the team is still missing a strong baseline anchor
-
-### Preprocessing diversity
-
-- When to use it: once the scientist has a stable implementation baseline
-- Why it might help: simpler preprocessing changes can sometimes yield diversity without a full model-family switch
-- Try it if: time budget is moderate and the likely payoff is better ensemble complementarity
-- Deprioritize if: the same family and preprocessing stack already dominate all evidence
-
-## Ensemble Construction Ideas
-
-### Simple averaging
-
-- When to use it: once at least two credible components exist
-- Why it might help: low-risk first ensemble test with minimal complexity
-- Try it if: components are meaningfully different and individually competent
-- Deprioritize if: there are not yet two believable components
-
-### Weighted averaging
-
-- When to use it: after simple averaging establishes that combination is worthwhile
-- Why it might help: can extract more value from uneven component quality
-- Try it if: one component is clearly stronger but diversity still matters
-- Deprioritize if: component instability makes weight tuning noisy
-
-### Stacked linear meta-models
-
-- When to use it: once the shortlist is stable enough to justify coordination cost
-- Why it might help: can combine strong and weakly complementary models more intelligently than a raw average
-- Try it if: OOF predictions are available and the strategy calls for serious ensemble work
-- Deprioritize if: the deadline is too near for careful validation
-
-### Shortlist-only ensembles late in the competition
-
-- When to use it: in the late phase, when exploration budget is shrinking
-- Why it might help: narrows work to high-confidence ingredients instead of endlessly growing the candidate pool
-- Try it if: the team already has a shortlist and wants disciplined final optimization
-- Deprioritize if: the run is still in broad exploration and the shortlist is premature
-
-## Simplification / Pruning Plays
-
-### Remove weak features
-
-- When to use it: when analysis identifies persistently low-value or noisy inputs
-- Why it might help: can reduce complexity while preserving or improving score
-- Try it if: importance or ablation evidence is strong
-- Deprioritize if: the evidence is ambiguous and the change would create brittle special cases
-
-### Remove brittle preprocessing
-
-- When to use it: when the current stack contains hacks that are not paying for themselves
-- Why it might help: simpler systems are easier to iterate on and often generalize better
-- Try it if: the complexity cost is high relative to the observed score gain
-- Deprioritize if: the preprocessing is central to the current best model
-
-### Simplify without material score loss
-
-- When to use it: whenever two approaches are close in score but far apart in complexity
-- Why it might help: creates more reliable components and easier future ensembling
-- Try it if: the simpler variant is near-parity
-- Deprioritize if: the simpler variant clearly loses too much
-
-## Validation / Robustness Diagnostics
-
-### Fold instability investigation
-
-- When to use it: when fold variance is high or one fold repeatedly behaves differently
-- Why it might help: can reveal overfitting, leakage, or brittle preprocessing
-- Try it if: results are noisy enough that rank-ordering experiments is difficult
-- Deprioritize if: fold behavior is already stable
-
-### CV/LB mismatch investigation
-
-- When to use it: after leaderboard submissions start disagreeing with CV
-- Why it might help: this is one of the strongest signals that the current validation strategy is misleading
-- Try it if: LB gains stop tracking CV gains
-- Deprioritize if: there is still no LB evidence at all
-
-### Leakage checks
-
-- When to use it: whenever scores move suspiciously fast or diagnostics look too good
-- Why it might help: catching leakage early prevents the team from optimizing the wrong thing
-- Try it if: feature behavior or leaderboard behavior looks implausible
-- Deprioritize if: there is no concrete reason to suspect leakage and time is extremely short
-
-## Late-Phase Conservative Plays
-
-### Prioritize reproducible high-confidence models
-
-- When to use it: in the final days of the competition month
-- Why it might help: stable high-confidence components are more valuable than speculative novelty near the deadline
-- Try it if: time remaining is short and the shortlist is already credible
-- Deprioritize if: the run is still missing a single strong anchor
-
-### Reduce novelty near deadline
-
-- When to use it: when the remaining submission budget is scarce
-- Why it might help: prevents spending final bandwidth on low-confidence experiments
-- Try it if: the strategy whitepaper classifies the run as exploitation or final submission discipline
-- Deprioritize if: the current path is clearly exhausted and no credible shortlist exists
-
-### Spend submissions on signal extraction, not speculative breadth
-
-- When to use it: once there are only a few submissions left
-- Why it might help: leaderboard slots become information resources that must be spent deliberately
-- Try it if: the team needs to distinguish between a small set of serious candidates
-- Deprioritize if: the run is still so early that broad anchoring is more valuable
-
-## Cold-Start / Late-Entry Plays
-
-### Front-load model-family comparison when time is short
-
-- When to use it: when the run starts with 3 or fewer days remaining and no experiments have been run
-- Why it might help: the most information-dense question in tabular Playground competitions is whether tree models are dominant over linear ones; answering it on day one determines the allocation for all remaining work
-- Try it if: the run is in bootstrap phase with no LB history
-- Deprioritize if: model-family comparison is already settled from prior experiment history
-
-### Linear anchor before tree exploration
-
-- When to use it: always, at the very start of a cold run
-- Why it might help: provides a reproducible reference point; reveals if the feature space is already well-conditioned; identifies whether leakage or fold issues exist before committing tree-model iterations
-- Try it if: `experiment.py` contains a usable baseline that has not yet been evaluated
-- Deprioritize if: a strong, validated anchor already exists from a prior run or prior day
-
-### Compress to two-model ensemble when deadline is within 3 days
-
-- When to use it: when fewer than 4 days remain and no shortlist exists
-- Why it might help: in constrained time, a simple average of the best linear model and the best tree model is often more reliable than chasing a third family or complex stacking; it avoids late-phase validation debt
-- Try it if: two distinct model families have been evaluated and both have validated CV scores
-- Deprioritize if: one model family is clearly dominant and there is no complementary diversity to gain
-
-## Tuning Failure Patterns
-
-### Hyperparameter tuning often stalls near the tree model ceiling
-
-- When to recognize it: when num_leaves, n_estimators, learning_rate, and min_child_samples all return to approximately the same CV score
-- Why it happens: on Playground Series datasets, the tree model ceiling on the given feature set is often hit quickly with conservative defaults. The signal that tuning has stalled is when 3+ tuning variants all land within ±0.0001 CV of the baseline
-- What to do instead: pivot to feature engineering or model-family diversity rather than continuing to tune the same model family
-- Evidence from mar28: LGBM num_leaves=63, deeper LGBM (1000 iterations lr=0.03), target encoding, and count features all failed to beat LGBM baseline CV 0.915855; all variants were within 0.0001 of baseline
-
-### Target encoding rarely helps tree models as a solo feature
-
-- When to recognize it: when TargetEncoder applied to high-variation categorical columns produces no CV gain on LGBM or CatBoost
-- Why it happens: gradient boosted trees already learn effective splits on categorical features (especially CatBoost with native categories). Target encoding pre-computes an average that the tree can already discover internally
-- What might still be useful: target-encoded features may add diversity when used in a different model family (e.g. as extra inputs to a logistic regression stack member), but this is speculative
-- Evidence from mar28: TargetEncoder on 13 high-variation columns: CV 0.915805 vs baseline 0.915855, discarded
-
-### Interaction features fail when tree models already learn them
-
-- When to recognize it: when a hand-crafted interaction feature (e.g. a binary flag or binned cross of two strong predictors) produces no CV gain on LGBM
-- Why it happens: gradient boosted trees with sufficient depth already split on the same combinations internally. Providing the interaction explicitly gives the model no new information it has not already captured
-- Diagnostic: if the analyst can confirm a clear threshold effect or subgroup concentration in the data (e.g. month-to-month × fiber optic), that does NOT mean a hand-crafted feature will help — it means the tree already made that split. Analyst structural findings should direct model selection (e.g. a model that cannot find non-linear interactions), not feature engineering for LGBM
-- Evidence from mar28: mtm_fiber binary flag, three-bin mtm×fiber tenure interaction, and continuous tenure×mtm_fiber all failed on LGBM (within ±0.0001 CV of baseline)
-
-### CatBoost tuning for divergence from LGBM backfires
-
-- When to recognize it: when tuning CatBoost toward higher accuracy (lower learning rate, more iterations, deeper trees) actually increases its OOF correlation with LGBM, not decreases it
-- Why it happens: both LGBM and CatBoost converge on the same decision boundaries when optimising for the same objective on the same features. Tuning makes them both more accurate — and more similar — not more orthogonal. True diversity requires structural differences (different model class, different feature space), not hyperparameter variation within the boosting family
-- Quantified: default CatBoost vs LGBM r=0.9953; tuned CatBoost (depth=7, iter=1000) vs LGBM r=0.9972 — tuning made it MORE correlated
-- Implication: do not expect hyperparameter tuning of a GBDT model to produce ensemble diversity; if two boosting models are highly correlated, tuning one of them will not fix it
-
-### All GBDT models hit a diversity wall on the same features
-
-- When to recognize it: when CatBoost, XGBoost, and LGBM all have OOF Pearson correlations above 0.990 with each other
-- Why it happens: all GBDT algorithms are optimising the same objective on the same ordinal-encoded feature matrix. They converge on the same prediction surface regardless of implementation differences
-- The r>0.990 wall means: ensemble gain from combining any two GBDT models on the same features is bounded at approximately +0.0001–0.0003 CV; rarely worth a submission slot unless it happens to yield the current best
-- What breaks the wall: (a) different model class (bagging, linear, neural), or (b) materially different feature representation that changes the input space for one model only
-- Evidence from mar28: CatBoost default r=0.9953, CatBoost tuned r=0.9972, XGBoost r=0.9972 — all GBDT above 0.990
-
-## Ensemble Construction — Advanced
-
-### 3-way GBDT ensemble as the practical ceiling for correlated models
-
-- When to use it: once two GBDT models are both in the shortlist and their 2-way ensemble gain is small (+0.001 or less)
-- Why it might help: a third GBDT model (e.g. XGBoost added to LGBM+CatBoost) can add a marginal +0.00006–0.00008 CV even when all three are above r=0.990 correlation with each other, because the averaging reduces variance across a slightly wider set of residuals
-- Ceiling: expect no more than +0.0001–0.0002 CV above the 2-way average; this is the practical limit for correlated GBDT ensembles
-- Evidence from mar28: LGBM+CatBoost simple average CV 0.916476, LGBM+CatBoost+XGBoost simple average CV 0.916592 (+0.000116)
-- Next step after hitting this ceiling: weight optimisation via OOF grid search (near-zero cost) before adding new model families
-
-### OOF weight grid search is the cheapest ensemble improvement
-
-- When to use it: once the component shortlist is locked (2–3 models with saved OOF predictions)
-- Why it might help: simple averaging assumes equal model quality; a grid search over weights in 0.1 steps can find a blend that weights the stronger model(s) appropriately
-- Cost: near-zero — no retraining, pure OOF computation
-- Ceiling: typically +0.0001–0.0003 CV above simple average on highly correlated models; larger gains possible if components have unequal quality
-- When to do it: before adding any new model family; exhausting weight search is always cheaper than running a new experiment
-
-### Bagging models (ExtraTrees/RF) as ensemble components have a solo CV floor
-
-- When to use it: considering ExtraTrees or RandomForest to add diversity to a GBDT ensemble
-- Hard constraint: if the bagging model's solo CV is more than 0.004 below the GBDT best, it will drag the ensemble down in all tested weighting schemes; do not include it regardless of structural orthogonality
-- Evidence from mar28: ExtraTrees solo CV 0.911426, GBDT best CV 0.916530 — gap 0.005; all ensemble combinations dragged below baseline. RF solo CV 0.910269, gap 0.006 — worse still
-- Suggested threshold: only include a bagging model in the ensemble if its solo CV is within 0.003 of the GBDT best; if the gap exceeds 0.004, discard immediately
-
-## ROC-AUC / Binary Classification Notes
-
-### Calibration may matter less than ranking
-
-- When to use it: as a reminder when tuning probability outputs
-- Why it might help: ROC-AUC is rank-based; well-calibrated probabilities are not required for the metric, so calibration fixes are low-priority unless ensemble weighting relies on them
-- Try it if: an analyst finding suggests calibration drift is affecting ensemble blending
-- Deprioritize if: the team is still in the anchoring phase
-
-### Class imbalance treatment requires analyst confirmation
-
-- When to use it: before applying class weights, oversampling, or threshold adjustments
-- Why it might help: treating a balanced dataset as imbalanced can hurt ROC-AUC; analyst should confirm the actual class distribution before the scientist applies imbalance corrections
-- Try it if: the churn rate appears low or the scientist proposes imbalance-specific changes
-- Deprioritize if: the analyst has already confirmed balanced class distribution
+It is a reusable bank of strategy ideas for inspiration.
+
+- It does not rank ideas.
+- It does not decide timing on its own.
+- It should stay broad enough that major areas do not get forgotten.
+- When time is abundant, no major area here should remain completely untested.
+
+## Analyst / EDA
+
+- class balance, subgroup balance, missingness, missingness by target
+- duplicates, near-duplicates, leakage risk, train/test shift
+- fold instability, subgroup instability, error concentration
+- high-cardinality columns, rare-category mass, dominant-category mass
+- monotonic patterns, outliers, suspiciously clean columns
+- target drift by subgroup, target drift by feature buckets
+- category overlap between train and test
+- feature-type mistakes, boolean-like numerics, numeric-like categoricals
+
+## Validation / Split Ideas
+
+- baseline k-fold, stratified folds, grouped folds, repeated folds
+- alternate random seeds for folds
+- adversarial validation, train-vs-test classifier
+- fold-by-fold diagnostics, per-fold ranking checks
+- subgroup-based validation checks
+- local CV vs leaderboard gap checks
+
+## Sampling / Weighting
+
+- class weights, sample weights, subgroup weights
+- under-sampling, over-sampling, balanced batches
+- hard-example emphasis, outlier down-weighting
+- pseudo-label confidence weighting
+
+## Missingness Handling
+
+- leave as native missing, median fill, mean fill, constant fill
+- missing indicators, grouped imputations, rare-category fill
+- missingness interaction features, missing-count features
+
+## Categorical Preprocessing
+
+- ordinal encoding
+- one-hot encoding
+- rare-bucket one-hot
+- capped one-hot
+- frequency encoding
+- count encoding
+- target encoding
+- leave-one-out encoding
+- hashing
+- native categorical handling
+- mixed categorical branches
+
+## Numeric Preprocessing
+
+- raw numeric features
+- standard scaling
+- robust scaling
+- min-max scaling
+- quantile transform
+- rank-gauss style transforms
+- log1p transforms
+- clipping
+- winsorizing
+- binning
+- polynomial features
+- spline-like expansions
+
+## Feature Generation
+
+- row sums, row means, row std, row mins, row maxes
+- row missing-count, row zero-count, row unique-count
+- count features, frequency features, rarity features
+- pairwise interactions, crosses, products, ratios, differences
+- binned interactions, threshold flags, monotonic buckets
+- groupby counts, groupby means, groupby target-free aggregates
+- category-combination keys
+- target-driven feature selection
+- feature pruning, feature clustering, correlation pruning
+- PCA, SVD, ICA, NMF, learned representations
+- anomaly scores, isolation-style signals
+- meta-features from secondary models
+
+## Model Families
+
+- logistic regression, ridge, lasso, elastic net
+- linear SVM, kernel SVM
+- kNN
+- naive Bayes
+- decision trees
+- RandomForest
+- ExtraTrees
+- HistGradientBoosting
+- LightGBM
+- XGBoost
+- CatBoost
+- MLP
+- wide-and-deep
+- TabNet
+- FT-Transformer
+- mixture-style specialist models
+
+## Tuning Directions
+
+- depth, leaves, learning rate, iterations
+- regularization, min child, min samples, gamma-style penalties
+- row subsampling, column subsampling, feature bagging
+- loss variants, objective variants, class weights
+- early stopping, longer training, shorter training
+- categorical-specific knobs
+- calibration variants
+- threshold-free ranking focus
+- alternate seeds
+
+## Stability / Repeatability
+
+- seed sweeps
+- repeat promising runs
+- repeat weak runs that may be noise
+- replicate with alternate fold seeds
+- bagging across seeds
+- bagging across folds
+
+## Diversity Building
+
+- alternate preprocessing branches
+- alternate feature branches
+- alternate model families
+- alternate seeds
+- alternate objectives
+- alternate validation views
+- weak-but-different components
+
+## Ensembling
+
+- simple average
+- weighted average
+- rank average
+- geometric mean
+- power mean
+- constrained weight search
+- hill climbing
+- greedy selection
+- stacking
+- preprocessing-branch blends
+- seed-bagged blends
+- shortlist-only blends
+- family-balanced blends
+
+## Diagnostics / Sanity Checks
+
+- OOF correlation
+- error overlap
+- disagreement analysis
+- feature-drop tests
+- ablations
+- subgroup performance checks
+- per-fold rank stability
+- CV/LB mismatch checks
+- leakage checks
+
+## Moonshots
+
+- pseudo-labeling
+- self-training
+- external data
+- synthetic data
+- transfer features
+- pretraining
+- teacher-student pipelines
+- two-stage residual pipelines
+- specialist submodels by subgroup
+- mixture-of-experts style routing
+- alternate objective shaping
+- top-solution pattern import
+- brute-force recipe sweeps

--- a/agents/strategist/strategy-lifecycle-guide.md
+++ b/agents/strategist/strategy-lifecycle-guide.md
@@ -1,0 +1,44 @@
+# Strategy Lifecycle Guide
+
+This file is owned by the strategist role.
+
+It is the reusable macro guide for sequencing strategy over the life of a competition.
+
+The cycle is:
+
+`EDA -> base models -> refinement -> ensembling -> moonshots`
+
+The full cycle stays alive throughout the competition.
+What changes over time is emphasis, not existence.
+
+## Default Emphasis By Competition Stage
+
+These percentages are soft targets for the mix of work across the cycle.
+
+They describe attention and effort over a rolling window.
+They are not exact experiment counts and they are not hard quotas.
+
+| Stage | EDA | Base Models | Refinement | Ensembling | Moonshots |
+|------|---:|---:|---:|---:|---:|
+| Opening (week 1 / first quarter) | 30 | 30 | 20 | 10 | 10 |
+| Build (week 2 / second quarter) | 20 | 25 | 30 | 15 | 10 |
+| Integration (week 3 / third quarter) | 10 | 15 | 25 | 35 | 15 |
+| Finale (week 4 / last quarter) | 5 | 10 | 15 | 25 | 45 |
+
+Use these as center points, not hard rules.
+The strategist may move a lane up or down when the run state justifies it, but should explain the deviation.
+
+## Pace Modifiers
+
+- **Slow:** shift about 10 points from ensembling and moonshots into EDA and base models.
+- **Fast:** shift about 10 points from EDA and base models into refinement and ensembling.
+- **Compressed:** keep every lane alive, but prefer representative probes over broad coverage.
+
+## Guardrails
+
+- Weak early foundation is a strategy problem.
+- Do not narrow too fast because one lane starts strong.
+- No major cookbook area should remain untouched when time is abundant.
+- Early strong CV does not justify skipping foundation work.
+- Late pressure compresses the cycle; it does not erase parts of it.
+- If coverage is thin, the strategist should slow the supervisor down.

--- a/agents/strategist/strategy-request.md
+++ b/agents/strategist/strategy-request.md
@@ -1,0 +1,13 @@
+# Strategy Request
+status: none
+id:
+at:
+trigger:
+
+## Volume
+
+## Coverage
+
+## Current
+
+## Knowledge

--- a/agents/strategist/strategy-whitepaper.md
+++ b/agents/strategist/strategy-whitepaper.md
@@ -1,93 +1,28 @@
 # Strategy Whitepaper
 
 ## Current Date
-March 29, 2026
+<fill on strategist refresh>
 
-## Deadline
-March 31, 2026
+## Deadline Assumption
+<fill on strategist refresh>
 
 ## Days Remaining
-3 (March 29, March 30, March 31) — 15 slots remaining (5 March 29 unused, 5 March 30, 5 March 31)
+<fill on strategist refresh>
 
-## Current Phase
-**Consolidation — all lanes exhausted. Final answer is 7b386f5. Remaining slots are insurance only.**
+## Read
+<coverage, pace, and current run shape>
 
-## Status Summary
-
-All 4 Playground Series S3–S6 lanes have been attempted and failed. Hill climbing on all available OOF arrays also confirmed: converges to CB=0.5/XGB=0.5 (same as OOF grid), which loses to equal 3-way in real harness (3963ca3 CV=0.916381 < 0.916540). OOF metrics cannot be trusted for weight selection.
-
-**Current best and final answer: 7b386f5, equal-weight LGBM+CB+XGB, CV=0.916540, LB=0.91396**
-
-**Two-feature-set blend** (Priority 4) is now closed — two-stage residual (cv=0.909887) confirmed the distribution mismatch wall. Zero-lift pattern is consistent across all experiments. No further lanes remain.
-
-**Confirmed non-starters (do not retry):**
-- RidgeCV meta-learner, hill climbing, OOF grid — all converge to CB+XGB only, which loses to equal 3-way.
-- All lanes in the "Closed Lanes" section below.
-
-## Slot Budget
-
-| Date | Slots | Plan |
-|------|-------|------|
-| March 29 | 5 available | Up to 3 experiments (seed bagging, original dataset, pseudo-labeling if time allows) |
-| March 30 | 5 available | Continue sequence; pseudo-labeling and/or two-feature-set; insurance re-submit 7b386f5 |
-| March 31 | 5 available | Final submission; 1–2 insurance slots held |
-| Reserve | — | 4–5 slots held across March 29–31 for insurance and final entry |
-
-Plan to use ~5–6 slots for experiments. Keep rest as insurance and for confirming 7b386f5 holds.
-
-## New Lanes — Priority Order for March 29–31
-
-### ~~1. Seed diversity bagging~~ — DONE, FAILED
-`ensemble_seed_bag_15` (3eaeb6c): CV=0.916382 < 0.916540. 15-model seed average worse than equal single-seed 3-way.
-
-### ~~2. Original Telco dataset blend~~ — DONE, FAILED
-`ensemble_lgbm_cb_xgb_orig` (b465548): CV=0.916341 < 0.916540. 7k IBM Telco rows introduce distribution noise.
-
-### ~~3. Soft pseudo-labeling~~ — DONE, FAILED
-`ensemble_lgbm_cb_xgb_pseudo` (48a125b): CV=0.916321, LB=0.91340. Worse on both metrics.
-
-### ~~Hill climbing (Caruana greedy)~~ — DONE, CONFIRMS EXISTING FINDING
-Converges in 2 steps to CB=0.5/XGB=0.5 (LGBM=0) — identical to OOF grid result. Harness result already exists as 3963ca3 (CV=0.916381 < 0.916540). OOF metrics cannot be used to select weights reliably.
-
-### ~~4. Two-feature-set blending~~ — CLOSED (never attempted, risk too high)
-Train the GBDT trio on two distinct feature representations; blend the resulting ensembles.
-- **Rationale for closing:** All prior feature engineering gave zero lift; two-stage residual (12b5ae5) returned cv=0.909887 (worst result), confirming distribution mismatch is a hard wall. Go condition (Branch B OOF correlation < 0.97) was never run, and with 2 days left and zero-lift pattern consistent across all experiments, the expected value is negative.
-- **Decision:** Closed. Do not attempt.
+## Emphasis
+Primary: <what should dominate now>
+Secondary: <what should stay materially active>
+Background: <what should keep moving lightly>
+Hold: <what should stay quiet for now>
 
 ## Guidance For The Supervisor
+1. <guidance>
+2. <guidance>
+3. <guidance if needed>
 
-1. **7b386f5 remains the anchor.** Every experiment is measured against CV=0.916540 / LB=0.91396.
-
-2. **Run lanes in priority order.** Do not skip to pseudo-labeling before attempting seed bagging; early wins compound. Do not run more than one experiment simultaneously.
-
-3. **OOF estimates are not sufficient for lanes 1 and 2.** Full harness CV must be run. For pseudo-labeling (lane 3), skip the CV gate entirely — LB is the only truth.
-
-4. **No hard gates between lanes.** A lane that fails does not close the next one. Keep running the sequence unless genuinely blocked.
-
-5. **These are the last remaining lanes.** There is no fifth idea in reserve. If all four fail, 7b386f5 is the final submission and no further exploration is warranted.
-
-6. **CV/LB gap is stable at ~0.0026** across all scored submissions. CV remains a reliable proxy except for pseudo-labeling.
-
-7. **Insurance:** Reserve at least 1 slot on March 31 to re-submit 7b386f5 if any experiment degrades the active submission.
-
-## Closed Lanes (Do Not Revisit)
-
-- MLP in any ensemble weight
-- LR in any ensemble weight
-- OOF-tuned weight optimisation (LGBM+CB+XGB or any subset)
-- OOF-tuned CB+XGB without LGBM
-- ExtraTrees / RandomForest
-- CatBoost depth tuning (OOM above depth 7)
-- LGBM hyperparameter tuning
-- Feature engineering (any family)
-- XGBoost solo tuning
-- Stacked meta-learners (including RidgeCV — confirmed noise-floor delta)
-
-## Pivot Conditions
-
-- **No hard gates between lanes.** Failure in one lane does not prevent the next.
-- If any LB submission returns below 0.9135: flag CV/LB gap widening to analyst before spending further slots.
-- If all 4 new lanes fail to beat 0.91396 on LB: accept 7b386f5 as the final answer and use March 31 slot for a clean final submission.
-
----
-*Refreshed: March 29, 2026. All lanes exhausted — 4 priority lanes + two-stage residual backlog all failed. Two-feature-set closed (high risk, zero-lift pattern). 15 slots remaining for insurance only. Final answer: 7b386f5, equal-weight LGBM+CB+XGB, CV=0.916540, LB=0.91396.*
+## Refresh Triggers
+- <condition>
+- <condition>

--- a/agents/supervisor/role.md
+++ b/agents/supervisor/role.md
@@ -17,7 +17,7 @@ Make the right calls at the right time: consume the strategist's long-horizon pl
 
 - **Branch:** `run`
 - **Directory:** `<root>/AutoKaggle/` (the shared repo checkout)
-- **Tracked files you own:** `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, `agents/supervisor/leaderboard-history.md`, `agents/supervisor/submission.py`
+- **Tracked files you own:** `agents/strategist/strategy-request.md`, `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, `agents/supervisor/leaderboard-history.md`, `agents/supervisor/submission.py`
 
 ## Path Variables
 
@@ -34,6 +34,8 @@ Resolve these dynamically at runtime from your current checkout. Do not commit m
 ## Cross-Agent File Paths
 
 ```text
+$REPO/agents/strategist/strategy-request.md        # factual strategist input owned by supervisor
+$REPO/agents/strategist/strategy-lifecycle-guide.md # strategist's reusable macro guide
 $REPO/agents/strategist/strategy-whitepaper.md      # strategist's current deadline-aware plan
 $REPO/agents/strategist/strategy-idea-cookbook.md   # strategist's reusable planning menu
 $REPO/agents/scientist/scientist-task.md            # active scientist task
@@ -54,7 +56,7 @@ Your own communication files live in `$REPO/agents/` and are read by the other a
 
 **What you CAN do:**
 - Read `harness/dataset.py`, `agents/scientist/experiment.py`, and all agent-owned results files
-- Write `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, and `agents/supervisor/leaderboard-history.md`
+- Write `agents/strategist/strategy-request.md`, `agents/scientist/scientist-task.md`, `agents/analyst/analyst-hypothesis.md`, and `agents/supervisor/leaderboard-history.md`
 - Edit `agents/supervisor/submission.py` if the submission-preparation helper needs adjustment
 - Read and operationalize `agents/strategist/strategy-whitepaper.md`, but do not treat it as self-executing
 - Create or update the long-lived `run` branch and shared runtime directories
@@ -76,7 +78,7 @@ Your own communication files live in `$REPO/agents/` and are read by the other a
 - Never commit while strategist, analyst, or scientist work is still in flight.
 - Prefer not to edit tracked files yourself while a subagent is running.
 - Before each commit, validate the tracked diff against role ownership. If a subagent touched files outside its allowed set, do not commit; send it back to fix the checkpoint first.
-- `agents/scientist/scientist-task.md` and `agents/analyst/analyst-hypothesis.md` are tracked live-control files. Do not commit them in an active state unless you are intentionally checkpointing a paused run. Normally clear them back to `status: none` before you commit.
+- `agents/strategist/strategy-request.md`, `agents/scientist/scientist-task.md`, and `agents/analyst/analyst-hypothesis.md` are tracked live-control files. Do not commit them in an active state unless you are intentionally checkpointing a paused run. Normally clear them back to `status: none` before you commit.
 
 ---
 
@@ -146,6 +148,21 @@ status: none
 EOF
 test -f agents/analyst/analyst-findings.md || echo "# Analyst Findings" > agents/analyst/analyst-findings.md
 test -f agents/analyst/analyst-knowledge.md || echo "# Analyst Knowledge" > agents/analyst/analyst-knowledge.md
+test -f agents/strategist/strategy-request.md || cat > agents/strategist/strategy-request.md <<'EOF'
+# Strategy Request
+status: none
+id:
+at:
+trigger:
+
+## Volume
+
+## Coverage
+
+## Current
+
+## Knowledge
+EOF
 test -f agents/supervisor/leaderboard-history.md || cat > agents/supervisor/leaderboard-history.md <<'EOF'
 # Leaderboard History
 
@@ -159,13 +176,13 @@ test -f agents/supervisor/leaderboard-history.md || cat > agents/supervisor/lead
 *No submissions yet.*
 EOF
 
-git add agents/scientist/scientist-task.md agents/scientist/scientist-results.md agents/scientist/scientist-knowledge.md agents/analyst/analyst-hypothesis.md agents/analyst/analyst-findings.md agents/analyst/analyst-knowledge.md agents/supervisor/leaderboard-history.md
+git add agents/strategist/strategy-request.md agents/scientist/scientist-task.md agents/scientist/scientist-results.md agents/scientist/scientist-knowledge.md agents/analyst/analyst-hypothesis.md agents/analyst/analyst-findings.md agents/analyst/analyst-knowledge.md agents/supervisor/leaderboard-history.md
 git diff --cached --quiet || git commit -m "init: run branch coordination files"
 ```
 
 ### 6. Obtain the initial strategy whitepaper
 
-Before the run goes live, ensure `agents/strategist/strategy-whitepaper.md` exists and is current.
+Before the run goes live, ensure `agents/strategist/strategy-request.md` is current and `agents/strategist/strategy-whitepaper.md` exists for today's date.
 
 Prefer invoking the strategist role on demand in the current repo. If episodic strategist invocation is unavailable, ask the human to open a temporary strategist session in the current repo and point it at `agents/strategist/role.md`.
 
@@ -183,12 +200,12 @@ If direct episodic invocation is unavailable, I may ask you to open a temporary 
 ```
 
 ```text
-1. Read agents/strategist/strategy-whitepaper.md, agents/scientist/scientist-knowledge.md, and agents/analyst/analyst-knowledge.md.
+1. Refresh agents/strategist/strategy-request.md from factual run state and durable knowledge, then obtain agents/strategist/strategy-whitepaper.md.
 2. Write an initial scientist task only if experiment work should begin immediately, then invoke the scientist.
 3. Post an initial analyst hypothesis only if you already need analyst evidence, then invoke the analyst.
 4. Review agents/supervisor/leaderboard-history.md before spending any submission budget.
 5. Create a recurring /loop 5m task for yourself, for example:
-   /loop 5m Review agents/strategist/strategy-whitepaper.md and agents/supervisor/leaderboard-history.md. If scientist work completed since your last review, also read agents/scientist/scientist-results.md and agents/scientist/scientist-knowledge.md. If analyst work completed since your last review, also read agents/analyst/analyst-findings.md and agents/analyst/analyst-knowledge.md. If there is new information since your last review, refresh strategy when needed, post or clear scientist and analyst requests, invoke episodic work when warranted, submit when warranted, commit only if no subagent is active, and leave the human a concise status note. Otherwise report that no changes were needed.
+   /loop 5m Review agents/strategist/strategy-whitepaper.md and agents/supervisor/leaderboard-history.md. If scientist work completed since your last review, also read agents/scientist/scientist-results.md and agents/scientist/scientist-knowledge.md. If analyst work completed since your last review, also read agents/analyst/analyst-findings.md and agents/analyst/analyst-knowledge.md. If there is new information since your last review, refresh agents/strategist/strategy-request.md when needed, invoke strategist refresh when needed, post or clear scientist and analyst requests, invoke episodic work when warranted, submit when warranted, commit only if no subagent is active, and leave the human a concise status note. Otherwise report that no changes were needed.
 ```
 
 Write the initial `agents/scientist/scientist-task.md` only when there is concrete experiment work to run. Use `harness/dataset.py` and `agents/scientist/experiment.py` to ground the task in the current evaluation contract and baseline implementation. Do not commit an active task file. The run has begun.
@@ -235,6 +252,45 @@ Request or invoke a strategist refresh when:
 - CV/LB behavior broke from expectations
 - the current scientist lane has plateaued or been exhausted
 - the remaining submission budget posture should change
+
+Before invoking the strategist, rewrite `agents/strategist/strategy-request.md` from factual run state and durable knowledge. Keep it factual. Do not pre-label the phase there.
+
+Use this shape:
+
+```markdown
+# Strategy Request
+status: active
+id: T-004
+at: 2026-03-04T09:20Z
+trigger: refresh
+
+## Volume
+- scientist_runs_total: <count>
+- scientist_runs_last_72h: <count>
+- analyst_sessions_total: <count>
+- analyst_sessions_last_72h: <count>
+- submissions_total: <count>
+- submissions_scored: <count>
+- submissions_pending: <count>
+
+## Coverage
+- analyst_topics: <comma-separated topics>
+- preprocess: <comma-separated ideas>
+- features: <comma-separated ideas>
+- models: <family(count), family(count)>
+- ensembles: <simple(count), weighted(count), stack(count)>
+- moonshots: <count or short note>
+
+## Current
+- best_cv: <score and hash>
+- best_lb: <score and hash or none>
+- active_scientist_lane: <short phrase>
+- active_analyst_topic: <short phrase or none>
+
+## Knowledge
+- AK-...: <fact>
+- SK-...: <fact>
+```
 
 The strategist recommends. You decide.
 
@@ -303,7 +359,7 @@ Before committing:
 
 1. Run `git diff --name-only` and verify the tracked changes match role ownership.
 2. If a subagent changed tracked files outside its allowed set, do not commit. Send it back to fix the checkpoint first.
-3. Clear `agents/scientist/scientist-task.md` and `agents/analyst/analyst-hypothesis.md` back to `status: none` unless you are intentionally recording a paused active state.
+3. Clear `agents/strategist/strategy-request.md`, `agents/scientist/scientist-task.md`, and `agents/analyst/analyst-hypothesis.md` back to `status: none` unless you are intentionally recording a paused active state.
 4. Commit the completed checkpoint with a message that describes the completed work, not the temporary control-file state.
 
 ### Update agents/supervisor/leaderboard-history.md
@@ -386,6 +442,7 @@ When escalating: state what is blocked, what you need, and what the team will do
 
 - **Strategy translation, not blind delegation.** Read the strategist's whitepaper, but convert it into operational guidance that fits the current run state.
 - **Evidence-based decisions.** Do not change direction without a reason. Cite results, findings, or LB signals explicitly. Treat unsupported empirical claims as hypotheses until they are verified.
+- **Do not abandon lanes too fast.** If time and budget are abundant, do not drop a strategy after one failed experiment. Prefer at least one nearby follow-up before parking it.
 - **Selective submission.** Not every kept experiment warrants a submission. Submit on meaningful jumps or genuinely different approaches. Late in the competition, use remaining submissions to extract signal.
 - **Targeted analysis.** "Does removing feature X reduce fold variance given fold 3 consistently underperforms?" is actionable. "Investigate feature X" is not.
 - **Respect role boundaries.** If you need dataset evidence, ask the analyst. Do not inspect the raw dataset yourself.


### PR DESCRIPTION
## Summary
- split strategist guidance into a lifecycle guide, factual strategy request, whitepaper, and broad idea cookbook
- update supervisor and shared docs to use supervisor-owned strategy requests and strategist-owned lifecycle guidance
- simplify the whitepaper template and make the cookbook an inspiration-oriented strategy bank

Closes #17