### PR TITLE
Fix runner control-file handling

### DIFF
--- a/harness/analysis_runner.py
+++ b/harness/analysis_runner.py
@@ -13,6 +13,7 @@ DEFAULT_ERRORS_FILENAME = "analysis-errors.md"
 
 @dataclass(frozen=True)
 class HypothesisMetadata:
+    status: str
     title: str
     question: str
     reference: str | None
@@ -31,6 +32,9 @@ def main() -> None:
 
     hypothesis_text = hypothesis_file.read_text()
     metadata = _extract_hypothesis_metadata(hypothesis_text)
+    if metadata.status != "active":
+        print("status: no_active_hypothesis")
+        return
 
     completed = subprocess.run(
         [sys.executable, str(analysis_path)],
@@ -84,6 +88,7 @@ def _extract_hypothesis_metadata(hypothesis_text: str) -> HypothesisMetadata:
     fields = _parse_key_value_fields(hypothesis_text)
     question = fields.get("q") or _extract_legacy_question(hypothesis_text) or "Analysis"
     return HypothesisMetadata(
+        status=fields.get("status", "none"),
         title=fields.get("id") or question,
         question=question,
         reference=fields.get("reference"),

--- a/harness/scientist_runner.py
+++ b/harness/scientist_runner.py
@@ -283,7 +283,11 @@ def _best_kept_score(results_file: Path) -> float | None:
 
 
 def _evaluate_keep_if(expression: str, score: float) -> bool:
-    match = re.fullmatch(r"mean_cv_roc_auc\s*(>=|>|<=|<)\s*([0-9]*\.?[0-9]+)", expression.strip())
+    match = re.fullmatch(
+        r"mean_cv_roc_auc\s*(>=|>|<=|<)\s*([+-]?(?:inf|infinity|[0-9]*\.?[0-9]+))",
+        expression.strip(),
+        flags=re.IGNORECASE,
+    )
     if match is None:
         raise ValueError(f"unsupported keep_if expression: {expression}")
     operator, raw_threshold = match.groups()

--- a/tests/test_analysis_runner.py
+++ b/tests/test_analysis_runner.py
@@ -12,6 +12,35 @@ from harness import analysis_runner
 
 
 class AnalysisRunnerTests(unittest.TestCase):
+    def test_inactive_hypothesis_exits_without_running(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            hypothesis_file = root / "analyst-hypothesis.md"
+            findings_file = root / "analyst-findings.md"
+            hypothesis_file.write_text("# Active Analyst Hypothesis\nstatus: none\n")
+
+            stdout = io.StringIO()
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "analysis_runner",
+                    "--hypothesis-file",
+                    str(hypothesis_file),
+                    "--findings-file",
+                    str(findings_file),
+                ],
+            ), mock.patch("harness.analysis_runner.subprocess.run") as run, mock.patch(
+                "sys.stdout",
+                stdout,
+            ):
+                analysis_runner.main()
+
+            run.assert_not_called()
+            self.assertEqual(stdout.getvalue().strip(), "status: no_active_hypothesis")
+            self.assertFalse(findings_file.exists())
+            self.assertFalse((root / "analysis-errors.md").exists())
+
     def test_success_appends_findings_without_stderr(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_scientist_runner.py
+++ b/tests/test_scientist_runner.py
@@ -210,6 +210,16 @@ class ScientistRunnerTests(unittest.TestCase):
         self.assertEqual(task.keep_if, "mean_cv_roc_auc >= 0.916540")
         self.assertEqual(task.reference, "result=S-003, knowledge=SK-009")
 
+    def test_missing_keep_if_defaults_to_unconditional_keep(self) -> None:
+        task = scientist_runner._extract_task_metadata(
+            "# Active Scientist Task\n"
+            "status: active\n"
+            "id: S-005\n"
+            "goal: Test default keep rule.\n"
+        )
+        self.assertEqual(task.keep_if, "mean_cv_roc_auc > -inf")
+        self.assertTrue(scientist_runner._evaluate_keep_if(task.keep_if, 0.0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make `analysis_runner` exit cleanly when the analyst hypothesis is inactive
- accept the documented default `keep_if` expression in `scientist_runner`
- add regression tests for both runner contracts

## Testing
- `uv run python -m unittest tests.test_analysis_runner tests.test_scientist_runner`
- `uv run python -m unittest discover -s tests`

Closes #27
Closes #28
