### PR TITLE
Refactor scientist harness around task IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Important untracked paths:
 
 Supervisor submissions should go through [harness/promotion_runner.py](harness/promotion_runner.py), not raw Kaggle CLI calls. The harness:
 
-- validates the artifact directory against the target hash
+- resolves the artifact directory from the scientist task id
+- reads the CV score for that task id from `agents/scientist/scientist-results.md`
 - generates `submission.csv` if needed
 - submits to Kaggle
 - polls until the submission is scored, errors, or times out
@@ -144,9 +145,7 @@ Example invocation:
 
 ```bash
 uv run python -m harness.promotion_runner \
-  --hash <hash> \
-  --artifact-dir artifacts/experiments/<hash> \
-  --cv-score <cv_score>
+  --task-id <task_id>
 ```
 
 ## Notes

--- a/agents/analyst/role.md
+++ b/agents/analyst/role.md
@@ -54,9 +54,9 @@ $REPO/agents/analyst/analyst-findings.md                   # durable append-only
 $REPO/agents/analyst/analyst-knowledge.md                  # concise durable analyst memory
 $REPO/agents/scientist/scientist-results.md                # experiment history
 $REPO/agents/scientist/experiment.py                       # scientist's current code
-$ARTIFACTS/experiments/<hash>/oof-preds.npy                # OOF probabilities aligned to training rows
-$ARTIFACTS/experiments/<hash>/model.pkl                    # fitted sklearn Pipeline
-$ARTIFACTS/experiments/<hash>/test-preds.npy               # test set probabilities
+$ARTIFACTS/<task_id>/oof-preds.npy                         # OOF probabilities aligned to training rows
+$ARTIFACTS/<task_id>/model.pkl                             # fitted sklearn Pipeline
+$ARTIFACTS/<task_id>/test-preds.npy                        # test set probabilities
 $DATA/train.csv                                            # training data
 $DATA/test.csv                                             # test data
 ```
@@ -64,7 +64,7 @@ $DATA/test.csv                                             # test data
 To read experiment code at a specific commit (works from any checkout):
 
 ```bash
-git show <hash>:agents/scientist/experiment.py
+git show <commit>:agents/scientist/experiment.py
 ```
 
 ## Setup
@@ -133,7 +133,7 @@ import pickle
 import numpy as np
 import pandas as pd
 
-ARTIFACTS_ROOT = "<root>/AutoKaggle/artifacts/experiments"
+ARTIFACTS_ROOT = "<root>/AutoKaggle/artifacts"
 DATA = "<root>/AutoKaggle/data"
 
 def main():

--- a/agents/scientist/scientist-results.md
+++ b/agents/scientist/scientist-results.md
@@ -1,4 +1,4 @@
 # Scientist Results
 
-| id | code | status | score | std | delta_best | desc |
-|----|------|--------|-------|-----|------------|------|
+| task_id | status | score | std | delta_best | desc |
+|---------|--------|-------|-----|------------|------|

--- a/agents/supervisor/leaderboard-history.md
+++ b/agents/supervisor/leaderboard-history.md
@@ -2,22 +2,9 @@
 
 ## Submission Ledger
 
-| hash | submitted_at | cv_score | status | lb_score | lb_rank | rationale |
-|------|--------------|----------|--------|----------|---------|-----------|
-| 4bc520f | 2026-03-28T13:06Z | 0.907919 | scored | 0.90504 | — | LR anchor — unmodified baseline_logistic_regression |
-| cbef1de | 2026-03-28T13:15Z | 0.915855 | scored | 0.91326 | — | LightGBM baseline n_estimators=500 lr=0.05 num_leaves=31 |
-| 9b27313 | 2026-03-28T14:10Z | 0.916476 | scored | 0.91390 | — | Simple average ensemble LGBM+CatBoost |
-| 393f8aa | 2026-03-28T~18:00Z | 0.916592 | scored | 0.50400 | — | ⚠️ BROKEN — 3-way LGBM+CatBoost+XGBoost; build_model returned fake OOF-loader, test preds were garbage |
-| 7b386f5 | 2026-03-28T18:46Z | 0.916540 | scored | 0.91396 | — | ensemble_lgbm_cb_xgb_fixed equal-weight proper fit/predict — **best LB** |
-| 48a125b | 2026-03-28T23:16Z | 0.916321 | scored | 0.91340 | — | pseudo-label test rows from 7b386f5 — worse on both CV and LB; lane closed |
+| task_id | submitted_at | cv_score | status | lb_score | lb_rank | rationale |
+|---------|--------------|----------|--------|----------|---------|-----------|
 
 ## Notes
 
-- CV/LB gaps (valid submissions): LR 0.00288, LGBM 0.00260, LGBM+CB 0.00258, LGBM+CB+XGB 0.00258 — gap is remarkably stable. CV is a reliable proxy for LB.
-- 393f8aa LB=0.504 is NOT a real score — discard (fake OOF-loader bug).
-- Best valid LB: **0.91396** (7b386f5, ensemble_lgbm_cb_xgb_fixed)
-- OOF grid showed CB=0.5/XGB=0.5/LGBM=0.0 as optimal, but real training of CB+XGB only (3963ca3, cv=0.916381) scored worse than equal 3-way (7b386f5, cv=0.916540). OOF-grid weights don't transfer to real training.
-- March 28 budget exhausted (5/5). March 29: 5 fresh slots.
-- All post-best lanes exhausted: seed bagging (0.916382), orig blend (0.916341), pseudo-labeling (LB 0.9134), CB+XGB+MLP (0.916228), two-stage residual (0.909887) — all worse. Two-feature-set lane closed (zero-lift pattern from all prior feature engineering; too high risk with 2 days left).
-- **Final answer: 7b386f5 (CV=0.916540, LB=0.91396).** Remaining slots for insurance only.
-- Remaining: 5 slots March 29 (unused), 5 March 30, 5 March 31 = 15 slots. Reserve 1 slot March 31 for clean final re-submit of 7b386f5.
+*No submissions yet.*

--- a/agents/supervisor/role.md
+++ b/agents/supervisor/role.md
@@ -123,7 +123,7 @@ This downloads competition data and generates `data/folds.csv`. If it fails due 
 ### 4. Create the artifacts directory
 
 ```bash
-mkdir -p artifacts/experiments
+mkdir -p artifacts
 ```
 
 ### 5. Initialise missing communication files
@@ -138,8 +138,8 @@ EOF
 test -f agents/scientist/scientist-results.md || cat > agents/scientist/scientist-results.md <<'EOF'
 # Scientist Results
 
-| id | code | status | score | std | delta_best | desc |
-|----|------|--------|-------|-----|------------|------|
+| task_id | status | score | std | delta_best | desc |
+|---------|--------|-------|-----|------------|------|
 EOF
 test -f agents/scientist/scientist-knowledge.md || echo "# Scientist Knowledge" > agents/scientist/scientist-knowledge.md
 test -f agents/analyst/analyst-hypothesis.md || cat > agents/analyst/analyst-hypothesis.md <<'EOF'
@@ -168,8 +168,8 @@ test -f agents/supervisor/leaderboard-history.md || cat > agents/supervisor/lead
 
 ## Submission Ledger
 
-| hash | submitted_at | cv_score | status | lb_score | lb_rank | rationale |
-|------|--------------|----------|--------|----------|---------|-----------|
+| task_id | submitted_at | cv_score | status | lb_score | lb_rank | rationale |
+|---------|--------------|----------|--------|----------|---------|-----------|
 
 ## Notes
 
@@ -282,8 +282,8 @@ trigger: refresh
 - moonshots: <count or short note>
 
 ## Current
-- best_cv: <score and hash>
-- best_lb: <score and hash or none>
+- best_cv: <score and task_id>
+- best_lb: <score and task_id or none>
 - active_scientist_lane: <short phrase>
 - active_analyst_topic: <short phrase or none>
 
@@ -333,10 +333,10 @@ status: active
 id: A-018
 at: 2026-03-29T10:45Z
 q: <specific yes/no question>
-reference: experiment=f03f610, knowledge=AK-012
+reference: task_id=S-017, knowledge=AK-012
 ```
 
-`reference:` is optional. Use it only when a specific experiment hash or knowledge entry should anchor the investigation.
+`reference:` is optional. Use it only when a specific experiment task id or knowledge entry should anchor the investigation.
 
 Only one hypothesis at a time. Wait for new findings on the current hypothesis before replacing it.
 
@@ -373,10 +373,10 @@ Use this structure:
 
 ## Submission Ledger
 
-| hash | submitted_at | cv_score | status | lb_score | lb_rank | rationale |
-|------|--------------|----------|--------|----------|---------|-----------|
-| f03f610 | 2026-03-27T14:32Z | 0.916481 | scored | 0.91821 | 142 | Ridge meta-learner |
-| 3d9a201 | 2026-03-27T18:05Z | 0.914200 | pending | pending | pending | LGBM baseline |
+| task_id | submitted_at | cv_score | status | lb_score | lb_rank | rationale |
+|---------|--------------|----------|--------|----------|---------|-----------|
+| S-018 | 2026-03-27T14:32Z | 0.916481 | scored | 0.91821 | 142 | Ridge meta-learner |
+| S-019 | 2026-03-27T18:05Z | 0.914200 | pending | pending | pending | LGBM baseline |
 
 ## Notes
 
@@ -385,7 +385,7 @@ Use this structure:
 
 Rules:
 
-- never add a second row for the same hash
+- never add a second row for the same task_id
 - write a row when you submit, with `status`, `lb_score`, and `lb_rank` set to `pending` if Kaggle has not scored it yet
 - update that row in place once the result is available
 - use the `Notes` section for CV/LB mismatch commentary, submission-budget posture, or failure context that does not belong in a row
@@ -399,14 +399,12 @@ The harness now owns the full submission lifecycle. Do not call raw `kaggle comp
 Workflow:
 
 ```text
-1. Verify the hash is not already present in agents/supervisor/leaderboard-history.md.
+1. Verify the task_id is not already present in agents/supervisor/leaderboard-history.md.
 2. Verify the daily submission budget still allows a new submission.
 3. Run harness/promotion_runner.py:
    uv run python -m harness.promotion_runner \
-     --hash <hash> \
-     --artifact-dir $ARTIFACTS/experiments/<hash> \
-     --cv-score <cv_score>
-4. Consume the JSON result from the harness. It validates the artifact, generates submission.csv if needed, submits to Kaggle, polls until scored or timeout/error, and returns fields such as submitted_at, submission_id, terminal_status, lb_score, lb_rank when available, and error_category on failure.
+     --task-id <task_id>
+4. Consume the JSON result from the harness. It resolves `artifacts/<task_id>/`, reads the matching CV score from `agents/scientist/scientist-results.md`, generates submission.csv if needed, submits to Kaggle, polls until scored or timeout/error, and returns fields such as submitted_at, submission_id, terminal_status, lb_score, lb_rank when available, and error_category on failure.
 5. Update agents/supervisor/leaderboard-history.md deterministically from that JSON and commit it.
 ```
 
@@ -421,7 +419,7 @@ You are the team's interface to the human. Report at the end of every wake, even
 ```text
 [<timestamp>] Supervisor wake - <trigger>
 
-Experiments: <N kept> kept, <N total> run. Best CV: <score> (<hash>).
+Experiments: <N kept> kept, <N total> run. Best CV: <score> (<task_id>).
 Strategy: <current phase and one-line objective>.
 Scientist: <one line on current direction>.
 Analyst: <last finding in one line, "invoked", or "idle">.

--- a/harness/experiment_runner.py
+++ b/harness/experiment_runner.py
@@ -1,4 +1,3 @@
-import argparse
 import builtins
 import importlib.util
 import multiprocessing as mp
@@ -12,15 +11,21 @@ from pathlib import Path
 os.environ.setdefault("LOKY_MAX_CPU_COUNT", str(os.cpu_count() or 1))
 
 from harness.dataset import N_SPLITS, TIME_BUDGET_SECONDS, EvaluationResult, evaluate_model
+from harness.scientist_contract import (
+    DEFAULT_EXPERIMENT_PATH,
+    default_artifact_dir,
+    normalize_repo_path,
+    read_task_metadata,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_EXPERIMENT_PATH = Path("agents/scientist/experiment.py")
 INVALID_EXIT_CODE = 2
 
 
 def main() -> None:
-    args = _parse_args()
-    experiment_path = _normalize_repo_path(args.experiment_path)
+    task = _load_active_task()
+    experiment_path = normalize_repo_path(DEFAULT_EXPERIMENT_PATH)
+    artifact_dir = normalize_repo_path(default_artifact_dir(task.task_id))
 
     total_start = time.perf_counter()
     deadline = time.monotonic() + TIME_BUDGET_SECONDS
@@ -101,21 +106,20 @@ def main() -> None:
         )
         raise SystemExit(124)
 
-    if args.artifact_dir is not None:
-        if oof_preds is None:
-            print("artifact generation failed: worker did not return out-of-fold predictions", file=sys.stderr)
-            raise SystemExit(1)
-        try:
-            _generate_artifacts(args.artifact_dir, oof_preds, experiment_path)
-        except BaseException as exc:
-            classification = _classify_exception(exc)
-            if classification == "invalid":
-                _print_invalid_summary(experiment_name, result.completed_folds, total_seconds)
-                print(traceback.format_exc(), file=sys.stderr, end="")
-                raise SystemExit(INVALID_EXIT_CODE) from exc
-            _print_error_summary(experiment_name, result.completed_folds, total_seconds)
+    if oof_preds is None:
+        print("artifact generation failed: worker did not return out-of-fold predictions", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        _generate_artifacts(artifact_dir, oof_preds, experiment_path)
+    except BaseException as exc:
+        classification = _classify_exception(exc)
+        if classification == "invalid":
+            _print_invalid_summary(experiment_name, result.completed_folds, total_seconds)
             print(traceback.format_exc(), file=sys.stderr, end="")
-            raise SystemExit(1) from exc
+            raise SystemExit(INVALID_EXIT_CODE) from exc
+        _print_error_summary(experiment_name, result.completed_folds, total_seconds)
+        print(traceback.format_exc(), file=sys.stderr, end="")
+        raise SystemExit(1) from exc
     _print_success_summary(
         experiment_name=experiment_name,
         result=result,
@@ -158,11 +162,20 @@ def _run_evaluation(messages: mp.Queue, experiment_path: Path) -> None:
         )
 
 
-def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--artifact-dir", type=Path)
-    parser.add_argument("--experiment-path", type=Path, default=DEFAULT_EXPERIMENT_PATH)
-    return parser.parse_args()
+def _load_active_task():
+    try:
+        task = read_task_metadata()
+    except FileNotFoundError:
+        print("error: active scientist task file is missing", file=sys.stderr)
+        raise SystemExit(1) from None
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    if task.status != "active":
+        print("error: scientist task must be active before experiment_runner can run", file=sys.stderr)
+        raise SystemExit(1)
+    return task
 
 
 def _terminate_process(process: mp.Process) -> None:
@@ -198,7 +211,7 @@ def _generate_artifacts(artifact_dir: Path, oof_preds, experiment_path: Path) ->
     experiment = _load_module_from_path(experiment_path, "autokaggle_experiment_artifacts")
     from harness.dataset import ID_COLUMN, TEST_PATH, load_train_with_folds, predict_positive_scores, split_xy
 
-    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_clean_artifact_dir(artifact_dir)
     np.save(artifact_dir / "oof-preds.npy", oof_preds)
 
     train_df = load_train_with_folds()
@@ -226,15 +239,18 @@ def _generate_artifacts(artifact_dir: Path, oof_preds, experiment_path: Path) ->
     print(f"artifacts written to {artifact_dir}")
 
 
-def _normalize_repo_path(path: Path) -> Path:
-    if path.is_absolute():
-        return path.resolve()
-    return (REPO_ROOT / path).resolve()
+def _ensure_clean_artifact_dir(artifact_dir: Path) -> None:
+    if artifact_dir.exists():
+        existing = {path.name for path in artifact_dir.iterdir()}
+        collision = existing.intersection({"oof-preds.npy", "model.pkl", "test-preds.npy", "submission.csv"})
+        if collision:
+            raise FileExistsError(f"artifacts already exist for task_id {artifact_dir.name!r}: {sorted(collision)}")
+    artifact_dir.mkdir(parents=True, exist_ok=True)
 
 
 def _load_module_from_path(module_path: Path, module_name: str):
     _ensure_repo_root_on_syspath()
-    resolved_path = _normalize_repo_path(module_path)
+    resolved_path = normalize_repo_path(module_path)
     spec = importlib.util.spec_from_file_location(module_name, resolved_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"could not load module from {resolved_path}")

--- a/harness/promotion_runner.py
+++ b/harness/promotion_runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -20,6 +19,7 @@ from kagglesdk.competitions.types.submission_status import SubmissionStatus
 
 from agents.supervisor.submission import create_submission_csv
 from harness.dataset import COMPETITION
+from harness.scientist_contract import normalize_repo_path, read_result_row
 
 DEFAULT_ARTIFACTS_ROOT = Path("artifacts")
 DEFAULT_SUBMISSION_FILENAME = "submission.csv"
@@ -28,7 +28,6 @@ DEFAULT_TIMEOUT_SECONDS = 30.0 * 60.0
 DEFAULT_LEADERBOARD_PAGE_SIZE = 100
 DEFAULT_SUBMISSIONS_PAGE_SIZE = 100
 DEFAULT_KAGGLE_ATTEMPTS = 3
-HASH_PATTERN = re.compile(r"[0-9a-f]{7,40}")
 TRANSIENT_KAGGLE_TOKENS = (
     "429",
     "500",
@@ -61,7 +60,7 @@ T = TypeVar("T")
 
 @dataclass
 class PromotionResult:
-    hash: str
+    task_id: str
     competition: str
     artifact_dir: str
     submission_file: str
@@ -97,15 +96,15 @@ def main() -> None:
 
 
 def _run_promotion(args: argparse.Namespace) -> PromotionResult:
-    artifact_dir = _normalize_repo_path(args.artifact_dir or _default_artifact_dir(args.hash))
-    submission_file = _normalize_repo_path(args.submission_file or artifact_dir / DEFAULT_SUBMISSION_FILENAME)
+    artifact_dir = normalize_repo_path(_default_artifact_dir(args.task_id))
+    submission_file = normalize_repo_path(args.submission_file or artifact_dir / DEFAULT_SUBMISSION_FILENAME)
     result = PromotionResult(
-        hash=args.hash,
+        task_id=args.task_id,
         competition=COMPETITION,
         artifact_dir=str(artifact_dir),
         submission_file=str(submission_file),
         submitted_at=None,
-        cv_score=args.cv_score,
+        cv_score=None,
         submission_id=None,
         kaggle_message=None,
         terminal_status="error",
@@ -117,7 +116,9 @@ def _run_promotion(args: argparse.Namespace) -> PromotionResult:
         error_message=None,
     )
 
-    _validate_inputs(args, artifact_dir, submission_file, result)
+    cv_result = _load_result_row(args.task_id, result)
+    result.cv_score = cv_result.score
+    _validate_inputs(args, artifact_dir, submission_file, cv_result, result)
     _ensure_submission_file(args, artifact_dir, submission_file, result)
 
     api = _create_api()
@@ -136,7 +137,7 @@ def _run_promotion(args: argparse.Namespace) -> PromotionResult:
         submit_response = _call_with_retry(
             lambda: api.competition_submit(
                 str(submission_file),
-                args.hash,
+                args.task_id,
                 COMPETITION,
                 quiet=True,
             )
@@ -162,7 +163,7 @@ def _run_promotion(args: argparse.Namespace) -> PromotionResult:
                 lambda: _get_submission(
                     api=api,
                     submission_id=result.submission_id,
-                    hash_value=args.hash,
+                    task_id=args.task_id,
                     submission_file=submission_file,
                     page_size=args.submissions_page_size,
                 )
@@ -215,12 +216,23 @@ def _run_promotion(args: argparse.Namespace) -> PromotionResult:
         time.sleep(args.poll_interval_seconds)
 
 
+def _load_result_row(task_id: str, result: PromotionResult):
+    try:
+        return read_result_row(task_id)
+    except ValueError as exc:
+        _fail(
+            result,
+            exit_code=1,
+            terminal_status="error",
+            error_category="validation_error",
+            error_message=str(exc),
+        )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--hash", required=True)
-    parser.add_argument("--artifact-dir", type=Path)
+    parser.add_argument("--task-id", required=True)
     parser.add_argument("--submission-file", type=Path)
-    parser.add_argument("--cv-score", type=float)
     parser.add_argument("--force-regenerate-submission-file", action="store_true")
     parser.add_argument("--poll-interval-seconds", type=float, default=DEFAULT_POLL_INTERVAL_SECONDS)
     parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
@@ -233,24 +245,9 @@ def _validate_inputs(
     args: argparse.Namespace,
     artifact_dir: Path,
     submission_file: Path,
+    cv_result,
     result: PromotionResult,
 ) -> None:
-    if HASH_PATTERN.fullmatch(args.hash) is None:
-        _fail(
-            result,
-            exit_code=1,
-            terminal_status="error",
-            error_category="validation_error",
-            error_message=f"hash must look like a git commit id, got {args.hash!r}",
-        )
-    if artifact_dir.name != args.hash:
-        _fail(
-            result,
-            exit_code=1,
-            terminal_status="error",
-            error_category="validation_error",
-            error_message=f"artifact directory must end with the hash {args.hash!r}",
-        )
     if not artifact_dir.is_dir():
         _fail(
             result,
@@ -266,6 +263,14 @@ def _validate_inputs(
             terminal_status="error",
             error_category="validation_error",
             error_message=f"missing required artifact: {artifact_dir / 'test-preds.npy'}",
+        )
+    if cv_result.score is None:
+        _fail(
+            result,
+            exit_code=1,
+            terminal_status="error",
+            error_category="validation_error",
+            error_message=f"task_id {args.task_id!r} does not have a numeric CV score in scientist-results.md",
         )
     if submission_file.exists() and not submission_file.is_file():
         _fail(
@@ -351,7 +356,7 @@ def _call_with_retry(call: Callable[[], T], attempts: int = DEFAULT_KAGGLE_ATTEM
 def _get_submission(
     api: KaggleApi,
     submission_id: int | None,
-    hash_value: str,
+    task_id: str,
     submission_file: Path,
     page_size: int,
 ):
@@ -366,7 +371,7 @@ def _get_submission(
     for submission in submissions:
         if submission is None:
             continue
-        if submission.description.strip() != hash_value:
+        if submission.description.strip() != task_id:
             continue
         if submission.file_name and submission.file_name != target_file_name:
             continue
@@ -470,14 +475,8 @@ def _is_transient_kaggle_error(exc: Exception) -> bool:
     return any(token in message for token in TRANSIENT_KAGGLE_TOKENS)
 
 
-def _default_artifact_dir(hash_value: str) -> Path:
-    return DEFAULT_ARTIFACTS_ROOT / "experiments" / hash_value
-
-
-def _normalize_repo_path(path: Path) -> Path:
-    if path.is_absolute():
-        return path.resolve()
-    return (REPO_ROOT / path).resolve()
+def _default_artifact_dir(task_id: str) -> Path:
+    return DEFAULT_ARTIFACTS_ROOT / task_id
 
 
 def _submission_status_name(status: Any) -> str | None:

--- a/harness/scientist_contract.py
+++ b/harness/scientist_contract.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EXPERIMENT_PATH = Path("agents/scientist/experiment.py")
+DEFAULT_RESULTS_PATH = Path("agents/scientist/scientist-results.md")
+DEFAULT_TASK_PATH = Path("agents/scientist/scientist-task.md")
+DEFAULT_ARTIFACTS_ROOT = Path("artifacts")
+TASK_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+RESULTS_HEADER = """# Scientist Results
+
+| task_id | status | score | std | delta_best | desc |
+|---------|--------|-------|-----|------------|------|
+"""
+
+
+@dataclass(frozen=True)
+class TaskMetadata:
+    status: str
+    task_id: str
+    goal: str
+    keep_if: str
+    reference: str | None
+
+
+@dataclass(frozen=True)
+class ResultRow:
+    task_id: str
+    status: str
+    score: float | None
+    std: float | None
+    delta_best: float | None
+    desc: str
+
+
+def normalize_repo_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path.resolve()
+    return (REPO_ROOT / path).resolve()
+
+
+def parse_task_metadata(task_text: str) -> TaskMetadata:
+    fields = _parse_key_value_fields(task_text)
+    task_id = fields.get("id") or "S-unknown"
+    _validate_task_id(task_id)
+    return TaskMetadata(
+        status=fields.get("status", "none"),
+        task_id=task_id,
+        goal=fields.get("goal") or "Unspecified experiment goal",
+        keep_if=fields.get("keep_if") or "mean_cv_roc_auc > -inf",
+        reference=fields.get("reference"),
+    )
+
+
+def read_task_metadata(task_path: Path = DEFAULT_TASK_PATH) -> TaskMetadata:
+    return parse_task_metadata(normalize_repo_path(task_path).read_text())
+
+
+def default_artifact_dir(task_id: str) -> Path:
+    _validate_task_id(task_id)
+    return DEFAULT_ARTIFACTS_ROOT / task_id
+
+
+def ensure_results_file(results_path: Path = DEFAULT_RESULTS_PATH) -> Path:
+    resolved = normalize_repo_path(results_path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    if not resolved.exists() or not resolved.read_text().strip():
+        resolved.write_text(RESULTS_HEADER)
+    return resolved
+
+
+def read_result_row(task_id: str, results_path: Path = DEFAULT_RESULTS_PATH) -> ResultRow:
+    _validate_task_id(task_id)
+    resolved = normalize_repo_path(results_path)
+    if not resolved.exists():
+        raise ValueError(f"results file does not exist: {resolved}")
+
+    matches: list[ResultRow] = []
+    for line in resolved.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or stripped.startswith("| task_id ") or stripped.startswith("|---------"):
+            continue
+        columns = [column.strip() for column in stripped.strip("|").split("|")]
+        if len(columns) != 6:
+            continue
+        if columns[0] != task_id:
+            continue
+        matches.append(
+            ResultRow(
+                task_id=columns[0],
+                status=columns[1],
+                score=_maybe_float(columns[2]),
+                std=_maybe_float(columns[3]),
+                delta_best=_maybe_float(columns[4]),
+                desc=columns[5],
+            )
+        )
+
+    if not matches:
+        raise ValueError(f"task_id {task_id!r} not found in {resolved}")
+    if len(matches) > 1:
+        raise ValueError(f"task_id {task_id!r} appears multiple times in {resolved}")
+    return matches[0]
+
+
+def _validate_task_id(task_id: str) -> None:
+    if TASK_ID_PATTERN.fullmatch(task_id) is None:
+        raise ValueError(f"invalid task id: {task_id!r}")
+
+
+def _parse_key_value_fields(task_text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in task_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        normalized_key = key.strip().lower()
+        if normalized_key not in {"status", "id", "at", "goal", "keep_if", "reference"}:
+            continue
+        normalized_value = value.strip()
+        if normalized_value and normalized_key not in fields:
+            fields[normalized_key] = normalized_value
+    return fields
+
+
+def _maybe_float(value: str | None) -> float | None:
+    if value is None or value == "-":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None

--- a/harness/scientist_runner.py
+++ b/harness/scientist_runner.py
@@ -1,5 +1,4 @@
 import argparse
-import hashlib
 import os
 import re
 import subprocess
@@ -9,15 +8,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from harness.experiment_runner import INVALID_EXIT_CODE
+from harness.scientist_contract import (
+    DEFAULT_EXPERIMENT_PATH,
+    ensure_results_file,
+    normalize_repo_path,
+    parse_task_metadata,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_EXPERIMENT_PATH = Path("agents/scientist/experiment.py")
 DEFAULT_ERRORS_FILENAME = "scientist-errors.md"
-RESULTS_HEADER = """# Scientist Results
-
-| id | code | status | score | std | delta_best | desc |
-|----|------|--------|-------|-----|------------|------|
-"""
 
 
 @dataclass(frozen=True)
@@ -39,23 +38,20 @@ class ExperimentSummary:
 
 def main() -> None:
     args = _parse_args()
-    task_file = _normalize_repo_path(args.task_file)
-    results_file = _normalize_repo_path(args.results_file)
-    experiment_path = _normalize_repo_path(args.experiment_path)
+    task_file = normalize_repo_path(args.task_file)
+    results_file = normalize_repo_path(args.results_file)
     errors_file = (
-        _normalize_repo_path(args.errors_file)
+        normalize_repo_path(args.errors_file)
         if args.errors_file
         else results_file.with_name(DEFAULT_ERRORS_FILENAME)
     )
-    artifact_root = _normalize_repo_path(args.artifact_root) if args.artifact_root else None
 
     task = _extract_task_metadata(task_file.read_text())
     if task.status != "active":
         print("status: no_active_task")
         return
-    code = _code_fingerprint(experiment_path)
     completed = subprocess.run(
-        _experiment_command(experiment_path=experiment_path, artifact_root=artifact_root, code=code),
+        _experiment_command(),
         capture_output=True,
         cwd=REPO_ROOT,
         env=_runner_env(),
@@ -64,11 +60,11 @@ def main() -> None:
     summary = _parse_summary(completed.stdout)
 
     if completed.returncode == INVALID_EXIT_CODE or summary.status == "invalid":
-        _append_invalid_entry(errors_file=errors_file, task=task, code=code, completed=completed)
+        _append_invalid_entry(errors_file=errors_file, task=task, completed=completed)
         _report_invalid(errors_file=errors_file, completed=completed)
         raise SystemExit(INVALID_EXIT_CODE)
 
-    _append_results_row(results_file=results_file, task=task, code=code, completed=completed, summary=summary)
+    _append_results_row(results_file=results_file, task=task, completed=completed, summary=summary)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -81,12 +77,6 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _normalize_repo_path(path: Path) -> Path:
-    if path.is_absolute():
-        return path.resolve()
-    return (REPO_ROOT / path).resolve()
-
-
 def _runner_env() -> dict[str, str]:
     env = os.environ.copy()
     repo_root = str(REPO_ROOT)
@@ -96,48 +86,20 @@ def _runner_env() -> dict[str, str]:
 
 
 def _extract_task_metadata(task_text: str) -> TaskMetadata:
-    fields = _parse_key_value_fields(task_text)
+    parsed = parse_task_metadata(task_text)
     return TaskMetadata(
-        status=fields.get("status", "none"),
-        task_id=fields.get("id") or "S-unknown",
-        goal=fields.get("goal") or "Unspecified experiment goal",
-        keep_if=fields.get("keep_if") or "mean_cv_roc_auc > -inf",
-        reference=fields.get("reference"),
+        status=parsed.status,
+        task_id=parsed.task_id,
+        goal=parsed.goal,
+        keep_if=parsed.keep_if,
+        reference=parsed.reference,
     )
-
-
-def _parse_key_value_fields(task_text: str) -> dict[str, str]:
-    fields: dict[str, str] = {}
-    for line in task_text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or ":" not in stripped:
-            continue
-        key, value = stripped.split(":", 1)
-        normalized_key = key.strip().lower()
-        if normalized_key not in {"status", "id", "at", "goal", "keep_if", "reference"}:
-            continue
-        normalized_value = value.strip()
-        if normalized_value and normalized_key not in fields:
-            fields[normalized_key] = normalized_value
-    return fields
-
-
-def _code_fingerprint(experiment_path: Path) -> str:
-    digest = hashlib.sha1(experiment_path.read_bytes()).hexdigest()
-    return digest[:7]
-
-
-def _experiment_command(experiment_path: Path, artifact_root: Path | None, code: str) -> list[str]:
-    command = [
+def _experiment_command() -> list[str]:
+    return [
         sys.executable,
         "-m",
         "harness.experiment_runner",
-        "--experiment-path",
-        str(experiment_path),
     ]
-    if artifact_root is not None:
-        command.extend(["--artifact-dir", str(artifact_root / "experiments" / code)])
-    return command
 
 
 def _parse_summary(stdout: str) -> ExperimentSummary:
@@ -168,7 +130,6 @@ def _maybe_float(value: str | None) -> float | None:
 def _append_invalid_entry(
     errors_file: Path,
     task: TaskMetadata,
-    code: str,
     completed: subprocess.CompletedProcess[str],
 ) -> None:
     errors_file.parent.mkdir(parents=True, exist_ok=True)
@@ -178,7 +139,6 @@ def _append_invalid_entry(
         f.write(f"## {task.task_id}\n")
         f.write(f"at: {_utc_timestamp()}\n")
         f.write(f"goal: {task.goal}\n")
-        f.write(f"code: {code}\n")
         if task.reference:
             f.write(f"reference: {task.reference}\n")
         f.write(f"exit_code: `{completed.returncode}`\n")
@@ -201,24 +161,16 @@ def _report_invalid(errors_file: Path, completed: subprocess.CompletedProcess[st
 def _append_results_row(
     results_file: Path,
     task: TaskMetadata,
-    code: str,
     completed: subprocess.CompletedProcess[str],
     summary: ExperimentSummary,
 ) -> None:
-    _ensure_results_file(results_file)
+    ensure_results_file(results_file)
     outcome = _terminal_outcome(task=task, completed=completed, summary=summary, results_file=results_file)
     desc = _table_cell(task.goal)
     with results_file.open("a") as f:
         f.write(
-            f"| {task.task_id} | {code} | {outcome['status']} | {outcome['score']} | {outcome['std']} | {outcome['delta_best']} | {desc} |\n"
+            f"| {task.task_id} | {outcome['status']} | {outcome['score']} | {outcome['std']} | {outcome['delta_best']} | {desc} |\n"
         )
-
-
-def _ensure_results_file(results_file: Path) -> None:
-    results_file.parent.mkdir(parents=True, exist_ok=True)
-    if results_file.exists() and results_file.read_text().strip():
-        return
-    results_file.write_text(RESULTS_HEADER)
 
 
 def _terminal_outcome(
@@ -268,13 +220,13 @@ def _best_kept_score(results_file: Path) -> float | None:
         return None
     for line in results_file.read_text().splitlines():
         stripped = line.strip()
-        if not stripped.startswith("|") or stripped.startswith("| id ") or stripped.startswith("|----"):
+        if not stripped.startswith("|") or stripped.startswith("| task_id ") or stripped.startswith("|---------"):
             continue
         columns = [column.strip() for column in stripped.strip("|").split("|")]
-        if len(columns) != 7:
+        if len(columns) != 6:
             continue
-        status = columns[2]
-        score = _maybe_float(columns[3])
+        status = columns[1]
+        score = _maybe_float(columns[2])
         if status != "kept" or score is None:
             continue
         if best is None or score > best:

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -2,6 +2,8 @@ import io
 import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 from harness import experiment_runner
@@ -54,19 +56,66 @@ class ExperimentRunnerTests(unittest.TestCase):
             ]
         )
 
-        with mock.patch.object(
-            sys,
-            "argv",
-            ["experiment_runner"],
-        ), mock.patch("harness.experiment_runner.mp.get_context", return_value=fake_context), redirect_stdout(
-            stdout
-        ), redirect_stderr(stderr):
+        task = mock.Mock(status="active", task_id="S-100")
+        with mock.patch("harness.experiment_runner.read_task_metadata", return_value=task), mock.patch(
+            "harness.experiment_runner.mp.get_context", return_value=fake_context
+        ), redirect_stdout(stdout), redirect_stderr(stderr):
             with self.assertRaises(SystemExit) as exc:
                 experiment_runner.main()
 
         self.assertEqual(exc.exception.code, experiment_runner.INVALID_EXIT_CODE)
         self.assertIn("status:            invalid", stdout.getvalue())
         self.assertIn("Traceback: boom", stderr.getvalue())
+
+    def test_main_requires_active_task(self) -> None:
+        stderr = io.StringIO()
+        task = mock.Mock(status="none", task_id="S-100")
+        with mock.patch("harness.experiment_runner.read_task_metadata", return_value=task), redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as exc:
+                experiment_runner.main()
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("scientist task must be active", stderr.getvalue())
+
+    def test_main_writes_artifacts_to_task_id_directory(self) -> None:
+        result = mock.Mock(
+            timed_out=False,
+            completed_folds=experiment_runner.N_SPLITS,
+            mean_score=0.91,
+            std_score=0.01,
+            training_seconds=1.5,
+        )
+        fake_context = _FakeContext(
+            [
+                {"type": "start", "experiment_name": "demo"},
+                {"type": "result", "experiment_name": "demo", "result": result, "oof_preds": mock.sentinel.oof},
+            ]
+        )
+        task = mock.Mock(status="active", task_id="S-101")
+
+        with TemporaryDirectory() as tmpdir:
+            artifact_dir = Path(tmpdir) / "S-101"
+            with mock.patch("harness.experiment_runner.read_task_metadata", return_value=task), mock.patch(
+                "harness.experiment_runner.mp.get_context", return_value=fake_context
+            ), mock.patch(
+                "harness.experiment_runner.default_artifact_dir", return_value=artifact_dir
+            ), mock.patch(
+                "harness.experiment_runner._generate_artifacts"
+            ) as generate_artifacts:
+                experiment_runner.main()
+
+        generate_artifacts.assert_called_once()
+        self.assertEqual(generate_artifacts.call_args.args[0], artifact_dir.resolve())
+        self.assertIs(generate_artifacts.call_args.args[1], mock.sentinel.oof)
+
+    def test_clean_artifact_dir_rejects_existing_terminal_outputs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            artifact_dir = Path(tmpdir) / "S-102"
+            artifact_dir.mkdir()
+            (artifact_dir / "oof-preds.npy").write_bytes(b"done")
+
+            with self.assertRaises(FileExistsError):
+                experiment_runner._ensure_clean_artifact_dir(artifact_dir)
 
     def test_classify_exception_marks_contract_failures_invalid(self) -> None:
         self.assertEqual(experiment_runner._classify_exception(ValueError("bad shape")), "invalid")

--- a/tests/test_promotion_runner.py
+++ b/tests/test_promotion_runner.py
@@ -11,6 +11,7 @@ from unittest import mock
 from kagglesdk.competitions.types.submission_status import SubmissionStatus
 
 from harness import promotion_runner
+from harness.scientist_contract import ResultRow
 
 
 class FakeSubmitResponse:
@@ -70,21 +71,21 @@ class FakeApi:
 
 class PromotionRunnerTests(unittest.TestCase):
     def test_main_emits_json_for_scored_submission(self) -> None:
-        hash_value = "abcdef1"
+        task_id = "S-018"
         with TemporaryDirectory() as tmpdir:
-            artifact_dir = Path(tmpdir) / hash_value
+            artifact_dir = Path(tmpdir) / task_id
             artifact_dir.mkdir()
             (artifact_dir / "test-preds.npy").write_bytes(b"ready")
 
             pending = FakeSubmission(
                 ref=42,
-                description=hash_value,
+                description=task_id,
                 file_name="submission.csv",
                 status=SubmissionStatus.PENDING,
             )
             complete = FakeSubmission(
                 ref=42,
-                description=hash_value,
+                description=task_id,
                 file_name="submission.csv",
                 status=SubmissionStatus.COMPLETE,
                 public_score="0.91821",
@@ -101,22 +102,27 @@ class PromotionRunnerTests(unittest.TestCase):
             exit_code, payload = self._run_main(
                 [
                     "promotion_runner",
-                    "--hash",
-                    hash_value,
-                    "--artifact-dir",
-                    str(artifact_dir),
-                    "--cv-score",
-                    "0.916481",
+                    "--task-id",
+                    task_id,
                     "--poll-interval-seconds",
                     "0.01",
                 ],
+                artifact_dir=artifact_dir,
+                result_row=ResultRow(
+                    task_id=task_id,
+                    status="kept",
+                    score=0.916481,
+                    std=0.001083,
+                    delta_best=0.0,
+                    desc="demo",
+                ),
                 create_api=api,
                 create_submission_csv=fake_create_submission_csv,
                 rank=142,
             )
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(payload["hash"], hash_value)
+        self.assertEqual(payload["task_id"], task_id)
         self.assertEqual(payload["terminal_status"], "scored")
         self.assertEqual(payload["submission_status"], "complete")
         self.assertEqual(payload["submission_id"], 42)
@@ -126,19 +132,19 @@ class PromotionRunnerTests(unittest.TestCase):
         self.assertEqual(payload["cv_score"], 0.916481)
         self.assertIsNone(payload["error_category"])
         self.assertEqual(len(api.submit_calls), 1)
-        self.assertEqual(api.submit_calls[0][1], hash_value)
+        self.assertEqual(api.submit_calls[0][1], task_id)
         self.assertTrue(payload["submission_file"].endswith("/submission.csv"))
 
     def test_main_times_out_with_machine_readable_error(self) -> None:
-        hash_value = "abcdef1"
+        task_id = "S-018"
         with TemporaryDirectory() as tmpdir:
-            artifact_dir = Path(tmpdir) / hash_value
+            artifact_dir = Path(tmpdir) / task_id
             artifact_dir.mkdir()
             (artifact_dir / "test-preds.npy").write_bytes(b"ready")
 
             pending = FakeSubmission(
                 ref=42,
-                description=hash_value,
+                description=task_id,
                 file_name="submission.csv",
                 status=SubmissionStatus.PENDING,
             )
@@ -147,15 +153,22 @@ class PromotionRunnerTests(unittest.TestCase):
             exit_code, payload = self._run_main(
                 [
                     "promotion_runner",
-                    "--hash",
-                    hash_value,
-                    "--artifact-dir",
-                    str(artifact_dir),
+                    "--task-id",
+                    task_id,
                     "--timeout-seconds",
                     "0",
                     "--poll-interval-seconds",
                     "0.01",
                 ],
+                artifact_dir=artifact_dir,
+                result_row=ResultRow(
+                    task_id=task_id,
+                    status="kept",
+                    score=0.916481,
+                    std=0.001083,
+                    delta_best=0.0,
+                    desc="demo",
+                ),
                 create_api=api,
                 create_submission_csv=self._fake_create_submission_csv,
             )
@@ -167,25 +180,47 @@ class PromotionRunnerTests(unittest.TestCase):
         self.assertIn("not scored", payload["error_message"])
 
     def test_main_reports_validation_errors_as_json(self) -> None:
-        hash_value = "abcdef1"
+        task_id = "S-018"
         with TemporaryDirectory() as tmpdir:
-            artifact_dir = Path(tmpdir) / hash_value
+            artifact_dir = Path(tmpdir) / task_id
             artifact_dir.mkdir()
 
             exit_code, payload = self._run_main(
                 [
                     "promotion_runner",
-                    "--hash",
-                    hash_value,
-                    "--artifact-dir",
-                    str(artifact_dir),
+                    "--task-id",
+                    task_id,
                 ],
+                artifact_dir=artifact_dir,
+                result_row=ResultRow(
+                    task_id=task_id,
+                    status="kept",
+                    score=0.916481,
+                    std=0.001083,
+                    delta_best=0.0,
+                    desc="demo",
+                ),
             )
 
         self.assertEqual(exit_code, 1)
         self.assertEqual(payload["terminal_status"], "error")
         self.assertEqual(payload["error_category"], "validation_error")
         self.assertIn("test-preds.npy", payload["error_message"])
+
+    def test_main_reports_missing_result_row_as_json(self) -> None:
+        exit_code, payload = self._run_main(
+            [
+                "promotion_runner",
+                "--task-id",
+                "S-999",
+            ],
+            result_lookup_error=ValueError("task_id 'S-999' not found in scientist-results.md"),
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["terminal_status"], "error")
+        self.assertEqual(payload["error_category"], "validation_error")
+        self.assertIn("S-999", payload["error_message"])
 
     def test_lookup_leaderboard_rank_walks_pages(self) -> None:
         entry1 = mock.Mock(team_name="team-a", score="0.92000")
@@ -208,16 +243,19 @@ class PromotionRunnerTests(unittest.TestCase):
 
         self.assertEqual(rank, 3)
 
-    def test_default_artifact_dir_is_tag_free(self) -> None:
+    def test_default_artifact_dir_uses_task_id(self) -> None:
         self.assertEqual(
-            promotion_runner._default_artifact_dir("abcdef1"),
-            Path("artifacts/experiments/abcdef1"),
+            promotion_runner._default_artifact_dir("S-018"),
+            Path("artifacts/S-018"),
         )
 
     def _run_main(
         self,
         argv: list[str],
         *,
+        artifact_dir: Path | None = None,
+        result_row: ResultRow | None = None,
+        result_lookup_error: Exception | None = None,
         create_api: FakeApi | None = None,
         create_submission_csv=None,
         rank: int | None = None,
@@ -228,6 +266,12 @@ class PromotionRunnerTests(unittest.TestCase):
             mock.patch("harness.promotion_runner.time.sleep", return_value=None),
         ]
 
+        if artifact_dir is not None:
+            patches.append(mock.patch("harness.promotion_runner._default_artifact_dir", return_value=artifact_dir))
+        if result_lookup_error is not None:
+            patches.append(mock.patch("harness.promotion_runner.read_result_row", side_effect=result_lookup_error))
+        elif result_row is not None:
+            patches.append(mock.patch("harness.promotion_runner.read_result_row", return_value=result_row))
         if create_api is not None:
             patches.append(mock.patch("harness.promotion_runner._create_api", return_value=create_api))
         if create_submission_csv is not None:

--- a/tests/test_scientist_runner.py
+++ b/tests/test_scientist_runner.py
@@ -16,8 +16,6 @@ class ScientistRunnerTests(unittest.TestCase):
             root = Path(tmpdir)
             task_file = root / "scientist-task.md"
             results_file = root / "scientist-results.md"
-            experiment_file = root / "experiment.py"
-            experiment_file.write_text("EXPERIMENT_NAME = 'demo'\n")
             task_file.write_text("# Active Scientist Task\nstatus: none\n")
 
             with mock.patch.object(
@@ -29,8 +27,6 @@ class ScientistRunnerTests(unittest.TestCase):
                     str(task_file),
                     "--results-file",
                     str(results_file),
-                    "--experiment-path",
-                    str(experiment_file),
                 ],
             ), mock.patch("harness.scientist_runner.subprocess.run") as run:
                 scientist_runner.main()
@@ -43,8 +39,6 @@ class ScientistRunnerTests(unittest.TestCase):
             root = Path(tmpdir)
             task_file = root / "scientist-task.md"
             results_file = root / "scientist-results.md"
-            experiment_file = root / "experiment.py"
-            experiment_file.write_text("EXPERIMENT_NAME = 'demo'\n")
             task_file.write_text(
                 "# Active Scientist Task\n"
                 "status: active\n"
@@ -77,29 +71,24 @@ class ScientistRunnerTests(unittest.TestCase):
                     str(task_file),
                     "--results-file",
                     str(results_file),
-                    "--experiment-path",
-                    str(experiment_file),
                 ],
             ), mock.patch("harness.scientist_runner.subprocess.run", return_value=completed):
                 scientist_runner.main()
 
             results = results_file.read_text()
-            code = scientist_runner._code_fingerprint(experiment_file)
-            self.assertIn("| S-001 |", results)
-            self.assertIn(f"| {code} | kept | 0.916540 | 0.001083 | +0.000000 | Test demo experiment. |", results)
+            self.assertIn("| task_id | status | score | std | delta_best | desc |", results)
+            self.assertIn("| S-001 | kept | 0.916540 | 0.001083 | +0.000000 | Test demo experiment. |", results)
 
     def test_success_discarded_uses_previous_best_for_delta(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             task_file = root / "scientist-task.md"
             results_file = root / "scientist-results.md"
-            experiment_file = root / "experiment.py"
-            experiment_file.write_text("EXPERIMENT_NAME = 'demo'\n")
             results_file.write_text(
                 "# Scientist Results\n\n"
-                "| id | code | status | score | std | delta_best | desc |\n"
-                "|----|------|--------|-------|-----|------------|------|\n"
-                "| S-000 | abc1234 | kept | 0.916540 | 0.001083 | +0.000000 | prior best |\n"
+                "| task_id | status | score | std | delta_best | desc |\n"
+                "|---------|--------|-------|-----|------------|------|\n"
+                "| S-000 | kept | 0.916540 | 0.001083 | +0.000000 | prior best |\n"
             )
             task_file.write_text(
                 "# Active Scientist Task\n"
@@ -131,27 +120,22 @@ class ScientistRunnerTests(unittest.TestCase):
                     str(task_file),
                     "--results-file",
                     str(results_file),
-                    "--experiment-path",
-                    str(experiment_file),
                 ],
             ), mock.patch("harness.scientist_runner.subprocess.run", return_value=completed):
                 scientist_runner.main()
 
             results = results_file.read_text()
-            self.assertIn("| S-002 |", results)
-            self.assertIn("| discarded | 0.916228 | 0.001041 | -0.000312 | Test weaker experiment. |", results)
+            self.assertIn("| S-002 | discarded | 0.916228 | 0.001041 | -0.000312 | Test weaker experiment. |", results)
 
     def test_invalid_writes_error_log_without_results_row(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             task_file = root / "scientist-task.md"
             results_file = root / "scientist-results.md"
-            experiment_file = root / "experiment.py"
-            experiment_file.write_text("EXPERIMENT_NAME = 'demo'\n")
             results_file.write_text(
                 "# Scientist Results\n\n"
-                "| id | code | status | score | std | delta_best | desc |\n"
-                "|----|------|--------|-------|-----|------------|------|\n"
+                "| task_id | status | score | std | delta_best | desc |\n"
+                "|---------|--------|-------|-----|------------|------|\n"
             )
             task_file.write_text(
                 "# Active Scientist Task\n"
@@ -177,8 +161,6 @@ class ScientistRunnerTests(unittest.TestCase):
                     str(task_file),
                     "--results-file",
                     str(results_file),
-                    "--experiment-path",
-                    str(experiment_file),
                 ],
             ), mock.patch("harness.scientist_runner.subprocess.run", return_value=completed), redirect_stderr(
                 stderr
@@ -187,8 +169,7 @@ class ScientistRunnerTests(unittest.TestCase):
                     scientist_runner.main()
 
             self.assertEqual(exc.exception.code, scientist_runner.INVALID_EXIT_CODE)
-            results = results_file.read_text()
-            self.assertNotIn("S-003", results)
+            self.assertNotIn("S-003", results_file.read_text())
             errors = (root / "scientist-errors.md").read_text()
             self.assertIn("## S-003", errors)
             self.assertIn("goal: Test broken experiment.", errors)


### PR DESCRIPTION
## Summary
- make `harness.experiment_runner` a zero-argument scientist harness bound to the active task id
- make `harness.promotion_runner` task-id-only and derive artifacts/CV from tracked scientist state
- update scientist results, leaderboard history, tests, and non-protected docs to the new task-id contract

## Testing
- `uv run python -m unittest discover -s tests`

Closes #30